### PR TITLE
Add Pluto HTML renderer and improve execution handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules
 Pluto.jl/
 vscode-jupyter/
 vscode-marimo/
+julia-vscode/

--- a/package.json
+++ b/package.json
@@ -16,6 +16,17 @@
   ],
   "main": "./dist/extension.js",
   "contributes": {
+    "notebookRenderer": [
+      {
+        "id": "pluto-html-renderer",
+        "displayName": "Pluto HTML Renderer",
+        "entrypoint": "./dist/pluto-renderer.js",
+        "mimeTypes": [
+          "text/html"
+        ],
+        "requiresMessaging": "always"
+      }
+    ],
     "notebooks": [
       {
         "type": "pluto-notebook",
@@ -51,6 +62,12 @@
         "title": "Restart Pluto Kernel",
         "category": "Pluto",
         "icon": "$(refresh)"
+      },
+      {
+        "command": "pluto-notebook.wrapInBeginEnd",
+        "title": "Wrap Cell in begin...end",
+        "category": "Pluto",
+        "icon": "$(code)"
       }
     ],
     "menus": {
@@ -84,8 +101,23 @@
           "when": "notebookType == pluto-notebook && pluto.kernelRunning",
           "group": "navigation/execute@2"
         }
+      ],
+      "notebook/cell/title": [
+        {
+          "command": "pluto-notebook.wrapInBeginEnd",
+          "when": "notebookType == pluto-notebook && notebookCellType == code",
+          "group": "inline@1"
+        }
       ]
-    }
+    },
+    "keybindings": [
+      {
+        "command": "pluto-notebook.wrapInBeginEnd",
+        "key": "ctrl+shift+b",
+        "mac": "cmd+shift+b",
+        "when": "notebookType == pluto-notebook && notebookCellFocused"
+      }
+    ]
   },
   "scripts": {
     "vscode:prepublish": "yarn run package",

--- a/samples/Basic.jl
+++ b/samples/Basic.jl
@@ -4,19 +4,40 @@
 using Markdown
 using InteractiveUtils
 
-# ╔═╡ ed09a15c-fb46-471e-b31f-9018047d881f
-y = x
-
-# ╔═╡ 3d34e610-d569-4a78-afbe-f3657b21bab4
+# ╔═╡ 2d9e9e13-f659-4fd3-b318-6bd3016fbc38
 begin
-    z = 5 + 2y
-    println(z)
+    using Plots
+    import ImageShow
+    using TestImages
+    using PlutoUI
 end
 
-# ╔═╡ 96d491cb-6963-4dab-9e6b-6da7b0d7ec70
-x = 1
+# ╔═╡ 1a453479-8e69-4c0e-8d2f-4578d5b74353
+@bind z Slider([1, 2, 3, 4, 5])
+
+# ╔═╡ 636f16e1-b458-4d38-abe1-92f24d7173da
+println(z)
+
+# ╔═╡ de2172e1-0c9c-44bb-bb14-f5935004e5cd
+begin
+    x = -pi:0.01:pi
+    y = sin.(x)
+end
+
+# ╔═╡ cfec83b9-4cb3-4f5d-b6ef-799076b66485
+plot(x, y)
+
+# ╔═╡ 08311720-0b8b-4c29-9ec3-4593231e3ad3
+testimage("mand")
+
+# ╔═╡ f64c9a4d-4ad8-4f0c-9641-9e9a1613ab0a
+
 
 # ╔═╡ Cell order:
-# ╠═ed09a15c-fb46-471e-b31f-9018047d881f
-# ╠═3d34e610-d569-4a78-afbe-f3657b21bab4
-# ╠═96d491cb-6963-4dab-9e6b-6da7b0d7ec70
+# ╠═2d9e9e13-f659-4fd3-b318-6bd3016fbc38
+# ╠═1a453479-8e69-4c0e-8d2f-4578d5b74353
+# ╠═636f16e1-b458-4d38-abe1-92f24d7173da
+# ╠═de2172e1-0c9c-44bb-bb14-f5935004e5cd
+# ╠═cfec83b9-4cb3-4f5d-b6ef-799076b66485
+# ╠═08311720-0b8b-4c29-9ec3-4593231e3ad3
+# ╠═f64c9a4d-4ad8-4f0c-9641-9e9a1613ab0a

--- a/src/PlutoNotebookController.ts
+++ b/src/PlutoNotebookController.ts
@@ -16,7 +16,6 @@ class PlutoKernel {
     private server: PlutoServer;
     private _isRunning = false;
     private cellExecutions = new Map<string, vscode.NotebookCellExecution>();
-    private cellTimeouts = new Map<string, NodeJS.Timeout>();  // Execution timeouts by cell ID
     private cellOutputs = new Map<string, { body?: string; mime?: string; logs?: LogEntry[] }>();
     private pendingDirectUpdates = new Map<string, NodeJS.Timeout>();  // Debounced direct updates
     private knownCellIds = new Set<string>();  // Cell IDs that Pluto knows about
@@ -74,12 +73,6 @@ class PlutoKernel {
         }
         this.pendingDirectUpdates.clear();
 
-        // Clear all execution timeouts
-        for (const timeoutId of this.cellTimeouts.values()) {
-            clearTimeout(timeoutId);
-        }
-        this.cellTimeouts.clear();
-
         // End all running executions
         for (const [cellId, execution] of this.cellExecutions) {
             try {
@@ -114,12 +107,6 @@ class PlutoKernel {
             await this.server.interruptAll();
         }
 
-        // Clear all execution timeouts
-        for (const timeoutId of this.cellTimeouts.values()) {
-            clearTimeout(timeoutId);
-        }
-        this.cellTimeouts.clear();
-
         // End all running executions
         for (const [cellId, execution] of this.cellExecutions) {
             console.log(`[PlutoKernel] Ending execution for ${cellId} due to interrupt`);
@@ -133,6 +120,18 @@ class PlutoKernel {
             } catch {}
         }
         this.cellExecutions.clear();
+    }
+
+    /**
+     * Set a bond value (for interactive widgets like Slider)
+     */
+    async setBond(name: string, value: unknown): Promise<void> {
+        if (!this._isRunning) {
+            console.log('[PlutoKernel] Cannot set bond, kernel not running');
+            return;
+        }
+        console.log(`[PlutoKernel] Setting bond ${name} to`, value);
+        await this.server.setBond(name, value);
     }
 
     /**
@@ -174,12 +173,6 @@ class PlutoKernel {
         const existingExecution = this.cellExecutions.get(cellId);
         if (existingExecution) {
             console.log(`[PlutoKernel] Ending previous execution for ${cellId}`);
-            // Clear existing timeout
-            const existingTimeout = this.cellTimeouts.get(cellId);
-            if (existingTimeout) {
-                clearTimeout(existingTimeout);
-                this.cellTimeouts.delete(cellId);
-            }
             try {
                 existingExecution.end(false, Date.now());
             } catch {}
@@ -193,34 +186,10 @@ class PlutoKernel {
         execution.start(Date.now());
         execution.clearOutput();
 
-        // Set up a timeout to prevent hanging executions (30 seconds)
-        const timeoutId = setTimeout(() => {
-            const exec = this.cellExecutions.get(cellId);
-            if (exec) {
-                console.log(`[PlutoKernel] Execution timeout for ${cellId}`);
-                exec.replaceOutput([
-                    new vscode.NotebookCellOutput([
-                        vscode.NotebookCellOutputItem.stderr('Execution timed out. Check Pluto server status.')
-                    ])
-                ]);
-                exec.end(false, Date.now());
-                this.cellExecutions.delete(cellId);
-                this.cellTimeouts.delete(cellId);
-            }
-        }, 30000);
-
-        // Store timeout to clear it later
-        this.cellTimeouts.set(cellId, timeoutId);
+        // Note: Timeout disabled - Pluto executions can take a long time for compilation
 
         // Update cell code in Pluto and run
         try {
-            // Check if Pluto knows about this cell
-            if (!this.knownCellIds.has(cellId)) {
-                console.log(`[PlutoKernel] Cell ${cellId} is new to Pluto, adding at index ${cell.index}`);
-                await this.server.addCell(cellId, cell.index, code);
-                this.knownCellIds.add(cellId);
-            }
-
             console.log(`[PlutoKernel] Sending updateCell for ${cellId}`);
             await this.server.updateCell(cellId, code);
             console.log(`[PlutoKernel] Sending runCell for ${cellId}`);
@@ -228,8 +197,6 @@ class PlutoKernel {
             console.log(`[PlutoKernel] runCell completed for ${cellId}`);
         } catch (err) {
             console.error('[PlutoKernel] Failed to run cell:', err);
-            clearTimeout(timeoutId);
-            this.cellTimeouts.delete(cellId);
             execution.replaceOutput([
                 new vscode.NotebookCellOutput([
                     vscode.NotebookCellOutputItem.error(err as Error)
@@ -360,16 +327,47 @@ class PlutoKernel {
         if (existingOutput.body) {
             const mime = existingOutput.mime || 'text/plain';
 
-            if (state.errored) {
+            if (state.errored || mime === 'application/vnd.pluto.stacktrace+object') {
+                // Handle Pluto error stacktrace
+                const errorText = this.parseErrorOutput(existingOutput.body, mime);
                 outputs.push(new vscode.NotebookCellOutput([
-                    vscode.NotebookCellOutputItem.error(new Error(existingOutput.body))
+                    vscode.NotebookCellOutputItem.stderr(errorText)
+                ]));
+                // Show wrap suggestion for "extra token" errors
+                if (existingOutput.body.includes('extra token after end of expression')) {
+                    this.showWrapSuggestion(cellId);
+                }
+            } else if (existingOutput.body.includes('extra token after end of expression')) {
+                // Handle "multiple expressions" syntax error
+                const errorText = this.addErrorHints(existingOutput.body);
+                outputs.push(new vscode.NotebookCellOutput([
+                    vscode.NotebookCellOutputItem.stderr(errorText)
+                ]));
+                // Show notification with wrap button
+                this.showWrapSuggestion(cellId);
+            } else if (existingOutput.body.includes('syntax:')) {
+                // Handle other syntax errors
+                outputs.push(new vscode.NotebookCellOutput([
+                    vscode.NotebookCellOutputItem.stderr(existingOutput.body)
+                ]));
+            } else if (mime === 'application/vnd.pluto.tree+object') {
+                // Pluto's tree object format - convert to readable text
+                const displayText = this.parsePlutoTreeObject(existingOutput.body);
+                outputs.push(new vscode.NotebookCellOutput([
+                    vscode.NotebookCellOutputItem.text(displayText, 'text/plain')
                 ]));
             } else if (mime === 'text/html') {
+                // Render HTML
                 outputs.push(new vscode.NotebookCellOutput([
                     vscode.NotebookCellOutputItem.text(existingOutput.body, 'text/html')
                 ]));
-            } else if (mime.startsWith('image/')) {
-                // Handle image output - body is base64 encoded
+            } else if (mime === 'image/svg+xml') {
+                // SVG is text-based, render as SVG (like julia-vscode)
+                outputs.push(new vscode.NotebookCellOutput([
+                    vscode.NotebookCellOutputItem.text(existingOutput.body, 'image/svg+xml')
+                ]));
+            } else if (mime === 'image/png' || mime === 'image/jpeg') {
+                // Binary images: decode base64 to Buffer (like julia-vscode)
                 try {
                     const buffer = Buffer.from(existingOutput.body, 'base64');
                     outputs.push(new vscode.NotebookCellOutput([
@@ -378,6 +376,18 @@ class PlutoKernel {
                 } catch {
                     outputs.push(new vscode.NotebookCellOutput([
                         vscode.NotebookCellOutputItem.text(existingOutput.body, 'text/plain')
+                    ]));
+                }
+            } else if (mime.endsWith('+json')) {
+                // JSON-based formats (Vega, Plotly, etc.)
+                try {
+                    const jsonData = JSON.parse(existingOutput.body);
+                    outputs.push(new vscode.NotebookCellOutput([
+                        vscode.NotebookCellOutputItem.json(jsonData, mime)
+                    ]));
+                } catch {
+                    outputs.push(new vscode.NotebookCellOutput([
+                        vscode.NotebookCellOutputItem.text(existingOutput.body, mime)
                     ]));
                 }
             } else {
@@ -401,12 +411,6 @@ class PlutoKernel {
 
             if (shouldEnd) {
                 console.log(`[PlutoKernel] Ending execution for ${cellId} (running=${state.running}, runtime=${state.runtime})`);
-                // Clear timeout
-                const timeoutId = this.cellTimeouts.get(cellId);
-                if (timeoutId) {
-                    clearTimeout(timeoutId);
-                    this.cellTimeouts.delete(cellId);
-                }
                 const success = !state.errored;
                 execution.end(success, Date.now());
                 this.cellExecutions.delete(cellId);
@@ -468,11 +472,47 @@ class PlutoKernel {
         if (existingOutput.body) {
             const mime = existingOutput.mime || 'text/plain';
 
-            if (mime === 'text/html') {
+            if (mime === 'application/vnd.pluto.stacktrace+object') {
+                // Handle Pluto error stacktrace
+                const errorText = this.parseErrorOutput(existingOutput.body, mime);
+                outputs.push(new vscode.NotebookCellOutput([
+                    vscode.NotebookCellOutputItem.stderr(errorText)
+                ]));
+                // Show wrap suggestion for "extra token" errors
+                if (existingOutput.body.includes('extra token after end of expression')) {
+                    this.showWrapSuggestion(cellId);
+                }
+            } else if (existingOutput.body.includes('extra token after end of expression')) {
+                // Handle "multiple expressions" syntax error
+                const errorText = this.addErrorHints(existingOutput.body);
+                outputs.push(new vscode.NotebookCellOutput([
+                    vscode.NotebookCellOutputItem.stderr(errorText)
+                ]));
+                // Show notification with wrap button
+                this.showWrapSuggestion(cellId);
+            } else if (existingOutput.body.includes('syntax:')) {
+                // Handle other syntax errors
+                outputs.push(new vscode.NotebookCellOutput([
+                    vscode.NotebookCellOutputItem.stderr(existingOutput.body)
+                ]));
+            } else if (mime === 'application/vnd.pluto.tree+object') {
+                // Pluto's tree object format - convert to readable text
+                const displayText = this.parsePlutoTreeObject(existingOutput.body);
+                outputs.push(new vscode.NotebookCellOutput([
+                    vscode.NotebookCellOutputItem.text(displayText, 'text/plain')
+                ]));
+            } else if (mime === 'text/html') {
+                // Render HTML
                 outputs.push(new vscode.NotebookCellOutput([
                     vscode.NotebookCellOutputItem.text(existingOutput.body, 'text/html')
                 ]));
-            } else if (mime.startsWith('image/')) {
+            } else if (mime === 'image/svg+xml') {
+                // SVG is text-based, render as SVG
+                outputs.push(new vscode.NotebookCellOutput([
+                    vscode.NotebookCellOutputItem.text(existingOutput.body, 'image/svg+xml')
+                ]));
+            } else if (mime === 'image/png' || mime === 'image/jpeg') {
+                // Binary images: decode base64 to Buffer
                 try {
                     const buffer = Buffer.from(existingOutput.body, 'base64');
                     outputs.push(new vscode.NotebookCellOutput([
@@ -481,6 +521,18 @@ class PlutoKernel {
                 } catch {
                     outputs.push(new vscode.NotebookCellOutput([
                         vscode.NotebookCellOutputItem.text(existingOutput.body, 'text/plain')
+                    ]));
+                }
+            } else if (mime.endsWith('+json')) {
+                // JSON-based formats (Vega, Plotly, etc.)
+                try {
+                    const jsonData = JSON.parse(existingOutput.body);
+                    outputs.push(new vscode.NotebookCellOutput([
+                        vscode.NotebookCellOutputItem.json(jsonData, mime)
+                    ]));
+                } catch {
+                    outputs.push(new vscode.NotebookCellOutput([
+                        vscode.NotebookCellOutputItem.text(existingOutput.body, mime)
                     ]));
                 }
             } else {
@@ -516,6 +568,259 @@ class PlutoKernel {
         }
     }
 
+    /**
+     * Parse Pluto's error output format
+     */
+    private parseErrorOutput(body: string, mime: string): string {
+        let errorText = body;
+
+        if (mime === 'application/vnd.pluto.stacktrace+object') {
+            try {
+                const errorObj = JSON.parse(body);
+                // Pluto sends stacktrace as an object with msg field
+                if (errorObj.msg) {
+                    errorText = errorObj.msg;
+                } else if (Array.isArray(errorObj) && errorObj.length > 0) {
+                    // Try to extract error message from the structure
+                    const firstFrame = errorObj[0];
+                    if (firstFrame.msg) {
+                        errorText = firstFrame.msg;
+                    } else {
+                        // Fallback to stringified JSON
+                        errorText = JSON.stringify(errorObj, null, 2);
+                    }
+                } else {
+                    // Fallback to stringified JSON
+                    errorText = JSON.stringify(errorObj, null, 2);
+                }
+            } catch {
+                // If parsing fails, return as-is
+            }
+        }
+
+        return this.addErrorHints(errorText);
+    }
+
+    /**
+     * Parse Pluto's tree object format into a readable string
+     * This handles application/vnd.pluto.tree+object mimetype
+     */
+    private parsePlutoTreeObject(body: string): string {
+        // Check if body is just an objectid (hex string) - Pluto sometimes sends this
+        if (/^[0-9a-f]{16}$/i.test(body)) {
+            console.log('[PlutoKernel] Tree object is just objectid, returning placeholder');
+            return '(computing...)';
+        }
+
+        try {
+            const treeObj = JSON.parse(body);
+            console.log('[PlutoKernel] Tree object structure:', JSON.stringify(treeObj, null, 2).substring(0, 3000));
+            const result = this.extractPlutoTree(treeObj);
+            console.log('[PlutoKernel] Tree object result:', result);
+            return result;
+        } catch (e) {
+            console.log('[PlutoKernel] Tree object parse error:', e);
+            // If parsing fails, return as-is (might be plain text)
+            return body;
+        }
+    }
+
+    /**
+     * Extract displayable text from Pluto tree object
+     */
+    private extractPlutoTree(obj: unknown): string {
+        if (obj === null || obj === undefined) return 'nothing';
+        if (typeof obj === 'string') return obj;
+        if (typeof obj === 'number' || typeof obj === 'boolean') return String(obj);
+
+        if (typeof obj !== 'object') return String(obj);
+
+        const record = obj as Record<string, unknown>;
+
+        // Check if it's a mime/body object (leaf value)
+        if ('mime' in record && 'body' in record) {
+            const body = record.body;
+            if (typeof body === 'string') return body;
+            return this.extractPlutoTree(body);
+        }
+
+        // Get Pluto type
+        const plutoType = record.type as string | undefined;
+
+        // Handle circular reference
+        if (plutoType === 'circular') {
+            return '(circular reference)';
+        }
+
+        // Handle Pair
+        if (plutoType === 'Pair' && 'key_value' in record) {
+            const kv = record.key_value as unknown[];
+            if (Array.isArray(kv) && kv.length === 2) {
+                return `${this.extractPlutoTree(kv[0])} => ${this.extractPlutoTree(kv[1])}`;
+            }
+        }
+
+        // Get prefix for type display
+        const prefix = (record.prefix_short || record.prefix || '') as string;
+
+        // Handle collections with elements
+        if ('elements' in record && Array.isArray(record.elements)) {
+            const elements = record.elements as unknown[];
+            const filtered = elements.filter(el => el !== 'more');
+
+            if (filtered.length === 0) {
+                // Empty collection - show type
+                return prefix || `${plutoType || 'Collection'}()`;
+            }
+
+            // Extract first few elements
+            const items: string[] = [];
+            for (let i = 0; i < Math.min(5, filtered.length); i++) {
+                const elem = filtered[i];
+                items.push(this.extractPlutoElement(elem));
+            }
+
+            const hasMore = elements.includes('more') || filtered.length > 5;
+            if (hasMore) {
+                items.push('...');
+            }
+
+            // Format based on type
+            const itemsStr = items.join(', ');
+            if (plutoType === 'Tuple') return `(${itemsStr})`;
+            if (plutoType === 'NamedTuple') return `(${itemsStr})`;
+            if (plutoType === 'Dict') return prefix ? `${prefix}(${itemsStr})` : `Dict(${itemsStr})`;
+            if (plutoType === 'Set') return prefix ? `${prefix}([${itemsStr}])` : `Set([${itemsStr}])`;
+            if (plutoType === 'Array') return prefix ? `${prefix}[${itemsStr}]` : `[${itemsStr}]`;
+            if (plutoType === 'struct') return prefix ? `${prefix}(${itemsStr})` : `(${itemsStr})`;
+
+            return prefix ? `${prefix}[${itemsStr}]` : `[${itemsStr}]`;
+        }
+
+        // Fallback to prefix/type display
+        if (prefix) return prefix;
+        if (plutoType) return `<${plutoType}>`;
+        if ('objectid' in record) return `<object>`;
+
+        return JSON.stringify(obj).substring(0, 100);
+    }
+
+    /**
+     * Extract a single element from Pluto tree elements array
+     * Pluto format: [index, [body, mime]] for Array/Set/Tuple
+     *               [key, value] for Dict (both are mimepairs)
+     *               [fieldname, [body, mime]] for struct/NamedTuple
+     */
+    private extractPlutoElement(elem: unknown): string {
+        if (elem === null || elem === undefined) return 'nothing';
+        if (typeof elem === 'string') return elem;
+        if (typeof elem === 'number' || typeof elem === 'boolean') return String(elem);
+
+        // Handle array element
+        if (Array.isArray(elem)) {
+            if (elem.length === 2) {
+                const [key, value] = elem;
+
+                // Check if value is a mimepair: [body, mime]
+                if (Array.isArray(value) && value.length === 2) {
+                    const [body, mime] = value;
+                    // For arrays with numeric index, just show the value
+                    if (typeof key === 'number') {
+                        return this.extractMimepairValue(body, mime as string);
+                    }
+                    // For named fields (struct, NamedTuple), show name = value
+                    if (typeof key === 'string') {
+                        const valueStr = this.extractMimepairValue(body, mime as string);
+                        return `${key} = ${valueStr}`;
+                    }
+                    // For Dict, key is also a mimepair
+                    if (Array.isArray(key) && key.length === 2) {
+                        const keyStr = this.extractMimepairValue(key[0], key[1] as string);
+                        const valueStr = this.extractMimepairValue(body, mime as string);
+                        return `${keyStr} => ${valueStr}`;
+                    }
+                }
+
+                // Fallback: treat as [key, value] pair
+                const valueStr = this.extractPlutoTree(value);
+                if (typeof key === 'number') {
+                    return valueStr;
+                }
+                const keyStr = this.extractPlutoTree(key);
+                return `${keyStr} = ${valueStr}`;
+            }
+            // Other arrays
+            return elem.map(e => this.extractPlutoTree(e)).join(', ');
+        }
+
+        // It's an object - delegate to extractPlutoTree
+        return this.extractPlutoTree(elem);
+    }
+
+    /**
+     * Extract value from Pluto mimepair [body, mime]
+     */
+    private extractMimepairValue(body: unknown, mime: string): string {
+        // If body is a string, return it directly
+        if (typeof body === 'string') {
+            return body;
+        }
+        // If body is a tree object, recurse
+        if (body && typeof body === 'object') {
+            return this.extractPlutoTree(body);
+        }
+        return String(body);
+    }
+
+    /**
+     * Add helpful hints for common errors
+     */
+    private addErrorHints(errorText: string): string {
+        // Add helpful hint for "extra token" error (multiple expressions in one cell)
+        if (errorText.includes('extra token after end of expression')) {
+            errorText += '\n\n💡 Pluto requires each cell to contain a single expression.';
+            errorText += '\n   Wrap your code in begin...end to fix this.';
+        }
+
+        return errorText;
+    }
+
+    /**
+     * Show a notification suggesting to wrap cell in begin...end
+     */
+    private showWrapSuggestion(cellId: string): void {
+        // Find the cell index
+        let cellIndex = -1;
+        for (let i = 0; i < this.notebook.cellCount; i++) {
+            const cell = this.notebook.cellAt(i);
+            if (getCellId(cell) === cellId) {
+                cellIndex = i;
+                break;
+            }
+        }
+
+        if (cellIndex === -1) return;
+
+        // Show notification with button
+        vscode.window.showWarningMessage(
+            'Pluto requires each cell to contain a single expression. Wrap your code in begin...end?',
+            'Wrap in begin...end',
+            'Dismiss'
+        ).then(async (selection) => {
+            if (selection === 'Wrap in begin...end') {
+                // Select the cell and run the wrap command
+                const notebookEditor = vscode.window.activeNotebookEditor;
+                if (notebookEditor && notebookEditor.notebook.uri.toString() === this.notebook.uri.toString()) {
+                    // Select the cell
+                    const range = new vscode.NotebookRange(cellIndex, cellIndex + 1);
+                    notebookEditor.selections = [range];
+                    // Run the wrap command
+                    await vscode.commands.executeCommand('pluto-notebook.wrapInBeginEnd');
+                }
+            }
+        });
+    }
+
     dispose(): void {
         this.stop();
     }
@@ -528,6 +833,11 @@ export class PlutoNotebookController implements vscode.Disposable {
     private controller: vscode.NotebookController;
     private kernels = new Map<string, PlutoKernel>();
     private disposables: vscode.Disposable[] = [];
+
+    // Expose kernels for bond updates
+    getKernelForNotebook(notebook: vscode.NotebookDocument): PlutoKernel | undefined {
+        return this.kernels.get(notebook.uri.toString());
+    }
 
     constructor() {
         this.controller = vscode.notebooks.createNotebookController(

--- a/src/PlutoServer.ts
+++ b/src/PlutoServer.ts
@@ -46,6 +46,10 @@ export class PlutoServer extends EventEmitter {
     // Track accumulated output state for each cell
     private cellOutputs: Map<string, { body?: string; mime?: string }> = new Map();
 
+    // Track known cell IDs and their order
+    private knownCellIds = new Set<string>();
+    private cellOrder: string[] = [];
+
     constructor() {
         super();
         this.clientId = this.generateId();
@@ -281,6 +285,12 @@ export class PlutoServer extends EventEmitter {
                 if (fullState?.cell_results) {
                     this.handleFullCellResults(fullState.cell_results as Record<string, unknown>);
                 }
+                // Track cell order from initial state
+                if (fullState?.cell_order && Array.isArray(fullState.cell_order)) {
+                    this.cellOrder = fullState.cell_order as string[];
+                    this.knownCellIds = new Set(this.cellOrder);
+                    console.log(`[PlutoServer] Initial cell order: ${this.cellOrder.length} cells`);
+                }
                 continue;
             }
 
@@ -444,8 +454,12 @@ export class PlutoServer extends EventEmitter {
         let output = this.cellOutputs.get(cellId) || { body: '', mime: 'text/plain' };
 
         if (subField === 'body') {
-            // Body can be string or object (for complex types)
-            if (typeof value === 'string') {
+            // Body can be string or object (for complex types like msgpack binary)
+            // First try to decode msgpack binary format
+            const decodedBody = this.tryDecodeMsgpackBinary(value, output.mime || 'text/plain');
+            if (decodedBody !== null) {
+                output.body = decodedBody;
+            } else if (typeof value === 'string') {
                 output.body = value;
             } else if (value && typeof value === 'object') {
                 // For complex output like errors, try to extract msg or stringify
@@ -484,17 +498,134 @@ export class PlutoServer extends EventEmitter {
         }
 
         let body = '';
+        const mime = (output.mime as string) || 'text/plain';
+
         if (output.body !== undefined) {
-            if (typeof output.body === 'string') {
+            // First, try to decode if it's already a msgpack binary format object
+            const decodedBody = this.tryDecodeMsgpackBinary(output.body, mime);
+            if (decodedBody !== null) {
+                body = decodedBody;
+            } else if (typeof output.body === 'string') {
                 body = output.body;
+            } else if (output.body instanceof Uint8Array || ArrayBuffer.isView(output.body)) {
+                // Handle binary data (like PNG images)
+                const bytes = output.body instanceof Uint8Array
+                    ? output.body
+                    : new Uint8Array((output.body as ArrayBufferView).buffer);
+                // Convert to base64 for binary images
+                if (mime.startsWith('image/') && mime !== 'image/svg+xml') {
+                    body = Buffer.from(bytes).toString('base64');
+                } else {
+                    // For text-based formats, decode as UTF-8
+                    body = Buffer.from(bytes).toString('utf-8');
+                }
+            } else if (Array.isArray(output.body)) {
+                // Might be a byte array as plain array
+                if (output.body.every((v: unknown) => typeof v === 'number')) {
+                    const bytes = new Uint8Array(output.body as number[]);
+                    if (mime.startsWith('image/') && mime !== 'image/svg+xml') {
+                        body = Buffer.from(bytes).toString('base64');
+                    } else {
+                        body = Buffer.from(bytes).toString('utf-8');
+                    }
+                } else {
+                    body = JSON.stringify(output.body);
+                }
             } else if (output.body && typeof output.body === 'object') {
+                // Other object types - stringify as fallback
                 body = JSON.stringify(output.body);
             }
         }
 
-        const mime = (output.mime as string) || 'text/plain';
-        console.log(`[PlutoServer] Extracted output: ${body.slice(0, 100)}, mime: ${mime}`);
+        console.log(`[PlutoServer] Extracted output mime: ${mime}, body length: ${body.length}, preview: ${body.slice(0, 50)}`);
         return { body, mime };
+    }
+
+    /**
+     * Try to decode msgpack binary format: {type: 18, data: {0: byte0, 1: byte1, ...}}
+     * Returns { bytes, isBase64 } or null if not in this format
+     * For binary data, always returns base64 to preserve bytes
+     */
+    private tryDecodeMsgpackBinary(body: unknown, mime: string): string | null {
+        console.log(`[PlutoServer] tryDecodeMsgpackBinary: type=${typeof body}, isArray=${Array.isArray(body)}, isUint8Array=${body instanceof Uint8Array}`);
+
+        // Handle Uint8Array or Buffer directly (from msgpack decoder)
+        if (body instanceof Uint8Array || Buffer.isBuffer(body)) {
+            const bytes = body instanceof Uint8Array ? body : new Uint8Array(body);
+            console.log(`[PlutoServer] Direct binary data: ${bytes.length} bytes, first 10: [${Array.from(bytes.slice(0, 10)).join(', ')}]`);
+
+            const isPNG = bytes[0] === 137 && bytes[1] === 80 && bytes[2] === 78 && bytes[3] === 71;
+            const isJPEG = bytes[0] === 255 && bytes[1] === 216 && bytes[2] === 255;
+            const isBinaryImage = isPNG || isJPEG || (mime.startsWith('image/') && mime !== 'image/svg+xml');
+
+            if (isBinaryImage) {
+                const result = Buffer.from(bytes).toString('base64');
+                console.log(`[PlutoServer] Direct binary -> base64: ${result.length} chars`);
+                return result;
+            } else {
+                return Buffer.from(bytes).toString('utf-8');
+            }
+        }
+
+        let dataObj: Record<string, number> | null = null;
+
+        // First, try to parse if it's a JSON string
+        let bodyToCheck = body;
+        if (typeof body === 'string') {
+            try {
+                bodyToCheck = JSON.parse(body);
+            } catch {
+                // Not JSON, keep as string
+                return null;
+            }
+        }
+
+        // Check if it's an object with type: 18 and data
+        if (bodyToCheck && typeof bodyToCheck === 'object' && !Array.isArray(bodyToCheck)) {
+            const bodyObj = bodyToCheck as Record<string, unknown>;
+            if (bodyObj.type === 18 && bodyObj.data && typeof bodyObj.data === 'object') {
+                dataObj = bodyObj.data as Record<string, number>;
+            }
+        }
+
+        if (!dataObj) return null;
+
+        // Extract bytes from the data object
+        const allKeys = Object.keys(dataObj);
+        const keys = allKeys.map(k => parseInt(k)).filter(k => !isNaN(k)).sort((a, b) => a - b);
+
+        console.log(`[PlutoServer] Msgpack binary: ${allKeys.length} total keys, ${keys.length} numeric keys`);
+
+        if (keys.length === 0) return null;
+
+        // Check if keys are contiguous
+        const maxKey = keys[keys.length - 1];
+        const minKey = keys[0];
+        console.log(`[PlutoServer] Key range: ${minKey} to ${maxKey}, expected length: ${maxKey - minKey + 1}`);
+
+        const bytes = new Uint8Array(maxKey + 1);
+        for (const key of keys) {
+            bytes[key] = dataObj[String(key)];
+        }
+
+        console.log(`[PlutoServer] Decoded msgpack binary for ${mime}: ${bytes.length} bytes, first 10: [${Array.from(bytes.slice(0, 10)).join(', ')}]`);
+
+        // Check if this looks like binary data (PNG, JPEG, etc.) by checking magic bytes
+        const isPNG = bytes[0] === 137 && bytes[1] === 80 && bytes[2] === 78 && bytes[3] === 71;
+        const isJPEG = bytes[0] === 255 && bytes[1] === 216 && bytes[2] === 255;
+        const isBinaryImage = isPNG || isJPEG || (mime.startsWith('image/') && mime !== 'image/svg+xml');
+
+        // Decode as base64 for binary images, UTF-8 for text (SVG, HTML, etc.)
+        let result: string;
+        if (isBinaryImage) {
+            result = Buffer.from(bytes).toString('base64');
+            console.log(`[PlutoServer] Base64 encoded (binary image detected): ${result.length} chars`);
+        } else {
+            result = Buffer.from(bytes).toString('utf-8');
+        }
+
+        console.log(`[PlutoServer] Decoded msgpack binary: ${bytes.length} bytes -> ${result.length} chars`);
+        return result;
     }
 
     /**
@@ -503,6 +634,21 @@ export class PlutoServer extends EventEmitter {
     async runCell(cellId: string): Promise<void> {
         this.sendMessage('run_multiple_cells', {
             cells: [cellId],
+        });
+    }
+
+    /**
+     * Set a bond value (for interactive widgets like Slider)
+     * This triggers reactive execution of dependent cells
+     */
+    async setBond(name: string, value: unknown): Promise<void> {
+        console.log(`[PlutoServer] Setting bond ${name} to`, value);
+        this.sendMessage('update_notebook', {
+            updates: [{
+                path: ['bonds', name],
+                op: 'replace',
+                value: { value },
+            }],
         });
     }
 
@@ -516,13 +662,18 @@ export class PlutoServer extends EventEmitter {
 
     /**
      * Add a new cell to the notebook
+     * Note: This only adds the cell_input. The cell_order is managed by Pluto automatically
+     * when the notebook is saved/synced.
      */
     async addCell(cellId: string, index: number, code: string = ''): Promise<void> {
         console.log(`[PlutoServer] Adding cell ${cellId} at index ${index}`);
 
-        // Send updates to add the cell_input and update cell_order
+        // First, add the cell to cell_inputs with its full structure
+        // Then add to cell_order
+        // This mimics how Pluto's frontend handles cell addition
         this.sendMessage('update_notebook', {
             updates: [
+                // Add to cell_inputs first
                 {
                     path: ['cell_inputs', cellId],
                     op: 'add',
@@ -532,18 +683,34 @@ export class PlutoServer extends EventEmitter {
                         code_folded: false,
                         metadata: {
                             disabled: false,
-                            show_logs: true,
-                            skip_as_script: false,
                         },
                     },
                 },
+                // Then add to cell_order
+                // Note: We use 'add' with path ending in '-' to append,
+                // or we need to replace the entire array
                 {
-                    path: ['cell_order', index],
-                    op: 'add',
-                    value: cellId,
+                    path: ['cell_order'],
+                    op: 'replace',
+                    value: this.getCellOrderWithNewCell(cellId, index),
                 },
             ],
         });
+
+        // Track this cell as known
+        this.knownCellIds.add(cellId);
+    }
+
+    /**
+     * Get the current cell order with a new cell inserted at the given index
+     */
+    private getCellOrderWithNewCell(cellId: string, index: number): string[] {
+        const newOrder = [...this.cellOrder];
+        // Insert at the specified index
+        newOrder.splice(index, 0, cellId);
+        // Update our tracked order
+        this.cellOrder = newOrder;
+        return newOrder;
     }
 
     /**
@@ -552,15 +719,20 @@ export class PlutoServer extends EventEmitter {
     async deleteCell(cellId: string, index: number): Promise<void> {
         console.log(`[PlutoServer] Deleting cell ${cellId} at index ${index}`);
 
+        // Update local tracking first
+        this.cellOrder = this.cellOrder.filter(id => id !== cellId);
+        this.knownCellIds.delete(cellId);
+
         this.sendMessage('update_notebook', {
             updates: [
                 {
-                    path: ['cell_order', index],
+                    path: ['cell_inputs', cellId],
                     op: 'remove',
                 },
                 {
-                    path: ['cell_inputs', cellId],
-                    op: 'remove',
+                    path: ['cell_order'],
+                    op: 'replace',
+                    value: this.cellOrder,
                 },
             ],
         });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -101,6 +101,57 @@ export function activate(context: vscode.ExtensionContext) {
             }
         })
     );
+
+    // Command to wrap cell content in begin...end
+    context.subscriptions.push(
+        vscode.commands.registerCommand('pluto-notebook.wrapInBeginEnd', async () => {
+            const notebookEditor = vscode.window.activeNotebookEditor;
+            if (!notebookEditor) {
+                vscode.window.showErrorMessage('No active notebook');
+                return;
+            }
+
+            const selections = notebookEditor.selections;
+            if (selections.length === 0) {
+                vscode.window.showErrorMessage('No cell selected');
+                return;
+            }
+
+            // Get the first selected cell
+            const cellRange = selections[0];
+            const cell = notebookEditor.notebook.cellAt(cellRange.start);
+
+            if (cell.kind !== vscode.NotebookCellKind.Code) {
+                vscode.window.showErrorMessage('Selected cell is not a code cell');
+                return;
+            }
+
+            const originalCode = cell.document.getText();
+
+            // Check if already wrapped in begin...end
+            const trimmed = originalCode.trim();
+            if (trimmed.startsWith('begin') && trimmed.endsWith('end')) {
+                vscode.window.showInformationMessage('Cell is already wrapped in begin...end');
+                return;
+            }
+
+            // Wrap in begin...end with proper indentation
+            const lines = originalCode.split('\n');
+            const indentedLines = lines.map(line => line ? '    ' + line : line);
+            const wrappedCode = 'begin\n' + indentedLines.join('\n') + '\nend';
+
+            // Replace cell content
+            const edit = new vscode.WorkspaceEdit();
+            const fullRange = new vscode.Range(
+                cell.document.positionAt(0),
+                cell.document.positionAt(cell.document.getText().length)
+            );
+            edit.replace(cell.document.uri, fullRange, wrappedCode);
+            await vscode.workspace.applyEdit(edit);
+
+            vscode.window.showInformationMessage('Cell wrapped in begin...end');
+        })
+    );
 }
 
 /**

--- a/src/pluto-renderer.ts
+++ b/src/pluto-renderer.ts
@@ -1,0 +1,200 @@
+/**
+ * Pluto HTML Renderer for VS Code Notebook
+ * Handles interactive elements like Slider, Checkbox, etc.
+ * and sends bond updates back to the extension
+ */
+
+import type { RendererContext, OutputItem } from 'vscode-notebook-renderer';
+
+interface PlutoBondMessage {
+    type: 'setBond';
+    name: string;
+    value: unknown;
+}
+
+/**
+ * Activate the renderer
+ */
+export function activate(context: RendererContext<void>) {
+    return {
+        renderOutputItem(outputItem: OutputItem, element: HTMLElement) {
+            const html = outputItem.text();
+            
+            // Create a container for the HTML
+            const container = document.createElement('div');
+            container.className = 'pluto-output';
+            
+            // Parse and render the HTML
+            container.innerHTML = html;
+            
+            // Find and setup interactive elements
+            setupInteractiveElements(container, context);
+            
+            // Clear previous content and add new
+            element.innerHTML = '';
+            element.appendChild(container);
+        }
+    };
+}
+
+/**
+ * Setup event listeners for interactive Pluto elements
+ */
+function setupInteractiveElements(container: HTMLElement, context: RendererContext<void>) {
+    // Find all input elements that might be bound
+    const inputs = container.querySelectorAll('input, select, textarea');
+    
+    inputs.forEach((input) => {
+        const inputEl = input as HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement;
+        
+        // Look for Pluto bond attribute or data attribute
+        // Pluto uses custom elements with specific attributes
+        const bondName = findBondName(inputEl);
+        
+        if (bondName) {
+            console.log(`[PlutoRenderer] Found bond: ${bondName}`);
+            setupBondListener(inputEl, bondName, context);
+        }
+    });
+    
+    // Also look for Pluto's custom <bond> elements
+    const bondElements = container.querySelectorAll('bond');
+    bondElements.forEach((bondEl) => {
+        const bondName = bondEl.getAttribute('def');
+        if (bondName) {
+            console.log(`[PlutoRenderer] Found <bond> element: ${bondName}`);
+            const input = bondEl.querySelector('input, select, textarea');
+            if (input) {
+                setupBondListener(input as HTMLInputElement, bondName, context);
+            }
+        }
+    });
+    
+    // Handle Pluto's standard HTML structure for sliders
+    // PlutoUI wraps inputs in specific structures
+    setupPlutoUISliders(container, context);
+}
+
+/**
+ * Find the bond name from an input element
+ */
+function findBondName(input: HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement): string | null {
+    // Check various attributes that Pluto might use
+    const bondAttr = input.getAttribute('bond') ||
+                     input.getAttribute('data-bond') ||
+                     input.getAttribute('name') ||
+                     input.closest('bond')?.getAttribute('def');
+    
+    return bondAttr;
+}
+
+/**
+ * Setup a listener for bond value changes
+ */
+function setupBondListener(
+    input: HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement,
+    bondName: string,
+    context: RendererContext<void>
+) {
+    const sendValue = () => {
+        const value = getInputValue(input);
+        console.log(`[PlutoRenderer] Bond ${bondName} changed to:`, value);
+        
+        // Send message to extension
+        context.postMessage({
+            type: 'setBond',
+            name: bondName,
+            value: value
+        } as PlutoBondMessage);
+    };
+    
+    // Listen for input events
+    input.addEventListener('input', sendValue);
+    input.addEventListener('change', sendValue);
+}
+
+/**
+ * Get the value from an input element in the appropriate format
+ */
+function getInputValue(input: HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement): unknown {
+    if (input instanceof HTMLSelectElement) {
+        if (input.multiple) {
+            return Array.from(input.selectedOptions).map(opt => opt.value);
+        }
+        return input.value;
+    }
+    
+    if (input instanceof HTMLInputElement) {
+        switch (input.type) {
+            case 'checkbox':
+                return input.checked;
+            case 'number':
+            case 'range':
+                return parseFloat(input.value);
+            case 'date':
+            case 'datetime-local':
+                return input.value;
+            default:
+                return input.value;
+        }
+    }
+    
+    return (input as HTMLTextAreaElement).value;
+}
+
+/**
+ * Setup handlers for PlutoUI Slider components
+ * PlutoUI generates HTML like:
+ * <bond def="varname"><input type="range" ...></bond>
+ */
+function setupPlutoUISliders(container: HTMLElement, context: RendererContext<void>) {
+    // Find range inputs (sliders)
+    const rangeInputs = container.querySelectorAll('input[type="range"]');
+    
+    rangeInputs.forEach((input) => {
+        const rangeInput = input as HTMLInputElement;
+        
+        // Try to find the bond name from parent elements
+        let bondName = findBondNameFromParents(rangeInput);
+        
+        if (bondName) {
+            console.log(`[PlutoRenderer] Setting up slider for bond: ${bondName}`);
+            setupBondListener(rangeInput, bondName, context);
+        } else {
+            // If no bond name found, try to extract from surrounding HTML
+            // PlutoUI often includes the variable name in span elements
+            const parentHTML = rangeInput.parentElement?.outerHTML || '';
+            console.log(`[PlutoRenderer] Slider without bond name, parent HTML:`, parentHTML.slice(0, 200));
+        }
+    });
+}
+
+/**
+ * Find bond name by traversing parent elements
+ */
+function findBondNameFromParents(element: HTMLElement): string | null {
+    let current: HTMLElement | null = element;
+    
+    while (current) {
+        // Check for <bond def="..."> element
+        if (current.tagName.toLowerCase() === 'bond') {
+            const def = current.getAttribute('def');
+            if (def) return def;
+        }
+        
+        // Check for data-bond attribute
+        const dataBond = current.getAttribute('data-bond');
+        if (dataBond) return dataBond;
+        
+        // Check for pluto-bond class or similar
+        if (current.classList.contains('pluto-bond')) {
+            const bondName = current.getAttribute('data-name') || 
+                           current.getAttribute('data-var');
+            if (bondName) return bondName;
+        }
+        
+        current = current.parentElement;
+    }
+    
+    return null;
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,8 +20,11 @@ const extensionConfig = {
     libraryTarget: 'commonjs2'
   },
   externals: {
-    vscode: 'commonjs vscode' // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed, 📖 -> https://webpack.js.org/configuration/externals/
+    vscode: 'commonjs vscode', // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed, 📖 -> https://webpack.js.org/configuration/externals/
     // modules added here also need to be added in the .vscodeignore file
+    ws: 'commonjs ws', // ws module has dynamic requires that don't work with webpack
+    bufferutil: 'commonjs bufferutil',
+    'utf-8-validate': 'commonjs utf-8-validate',
   },
   resolve: {
     // support reading TypeScript and JavaScript files, 📖 -> https://github.com/TypeStrong/ts-loader
@@ -45,4 +48,37 @@ const extensionConfig = {
     level: "log", // enables logging required for problem matchers
   },
 };
-module.exports = [ extensionConfig ];
+
+/** @type WebpackConfig */
+const rendererConfig = {
+  target: 'web', // Renderer runs in browser context
+  mode: 'none',
+  entry: './src/pluto-renderer.ts',
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    filename: 'pluto-renderer.js',
+    libraryTarget: 'module',
+  },
+  experiments: {
+    outputModule: true,
+  },
+  resolve: {
+    extensions: ['.ts', '.js']
+  },
+  module: {
+    rules: [
+      {
+        test: /\.ts$/,
+        exclude: /node_modules/,
+        use: [
+          {
+            loader: 'ts-loader'
+          }
+        ]
+      }
+    ]
+  },
+  devtool: 'nosources-source-map',
+};
+
+module.exports = [ extensionConfig, rendererConfig ];


### PR DESCRIPTION
## Summary

- Add HTML renderer for interactive Pluto elements (Slider, Checkbox, etc.)
- Improve execution handling by removing timeouts (Pluto can take long for compilation)
- Add `wrapInBeginEnd` command with keyboard shortcut for multi-expression cells

## Features

### Pluto HTML Renderer (`pluto-renderer.ts`)
- Handles interactive HTML elements from PlutoUI
- Detects `<bond>` elements and input fields
- Sends bond value updates back to extension via messaging
- Supports range inputs, checkboxes, select elements

### Wrap in begin...end Command
- New command: `Pluto: Wrap Cell in begin...end`
- Keybinding: `Cmd+Shift+B` (Mac) / `Ctrl+Shift+B` (Windows/Linux)
- Useful for multi-expression cells in Pluto

### Improved Execution
- Removed 30-second timeout (Pluto first-run compilation can take longer)
- Better msgpack binary data handling for images
- Improved cell order tracking from server state
- Added `setBond` support for interactive widgets

## Test plan

- [ ] Build extension: `yarn compile`
- [ ] Package and install: `npx vsce package && cursor --install-extension *.vsix`
- [ ] Open a Pluto notebook and verify cell execution works without timeouts
- [ ] Test `Cmd+Shift+B` to wrap code in begin...end block
- [ ] Test HTML output rendering for cells with formatted output