### PR TITLE
Rename package from ModernPlutoClient to BetterPlutoClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-All notable changes to the "modern-pluto-client" extension will be documented in this file.
+All notable changes to the "better-pluto-client" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,7 +218,7 @@ node test-pluto-connection.js
 npx vsce package
 
 # 2. Cursor にインストール
-cursor --install-extension modern-pluto-client-0.0.1.vsix
+cursor --install-extension better-pluto-client-0.0.1.vsix
 
 # 3. インストール確認
 cursor --list-extensions | grep pluto
@@ -230,17 +230,17 @@ cursor --list-extensions | grep pluto
 
 ```bash
 # VS Code にインストール
-code --install-extension modern-pluto-client-0.0.1.vsix
+code --install-extension better-pluto-client-0.0.1.vsix
 ```
 
 ### アンインストール
 
 ```bash
 # Cursor からアンインストール
-cursor --uninstall-extension undefined_publisher.modern-pluto-client
+cursor --uninstall-extension undefined_publisher.better-pluto-client
 
 # VS Code からアンインストール
-code --uninstall-extension undefined_publisher.modern-pluto-client
+code --uninstall-extension undefined_publisher.better-pluto-client
 ```
 
 ### 開発中のデバッグ実行（推奨）
@@ -257,7 +257,7 @@ VSIX を作らずに素早くテストする場合：
 ### 動作確認
 
 1. `yarn compile` でビルド
-2. `npx vsce package && cursor --install-extension modern-pluto-client-0.0.1.vsix`
+2. `npx vsce package && cursor --install-extension better-pluto-client-0.0.1.vsix`
 3. Cursor を再起動
 4. `samples/Basic.jl` を開く
 5. セルの追加・削除・実行をテスト

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Modern Pluto Client
+# BetterPlutoClient
 
 A VS Code extension for editing Pluto.jl notebooks with **full native editor support**.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "modern-pluto-client",
-  "displayName": "ModernPlutoClient",
+  "name": "better-pluto-client",
+  "displayName": "BetterPlutoClient",
   "description": "View and edit Pluto.jl notebooks in VS Code with native notebook support",
   "version": "0.0.1",
   "engines": {


### PR DESCRIPTION
This PR renames the package from ModernPlutoClient to BetterPlutoClient.

## Changes
- Update package.json name and displayName
- Update README.md title
- Update CHANGELOG.md extension name reference
- Update CLAUDE.md installation/uninstallation commands

All references to the old package name have been updated consistently.