### PR TITLE
Update README.md and CLAUDE.md with BetterPlutoClient name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ node_modules
 
 # Reference implementations (for local development only)
 Pluto.jl/
+PlutoUI.jl/
 vscode-jupyter/
 vscode-marimo/
 julia-vscode/
+.DS_Store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# Modern Pluto Client - VS Code Extension
+# BetterPlutoClient - VS Code Extension
 
 ## プロジェクト概要
 
@@ -218,7 +218,7 @@ node test-pluto-connection.js
 npx vsce package
 
 # 2. Cursor にインストール
-cursor --install-extension modern-pluto-client-0.0.1.vsix
+cursor --install-extension better-pluto-client-0.0.1.vsix
 
 # 3. インストール確認
 cursor --list-extensions | grep pluto
@@ -230,17 +230,17 @@ cursor --list-extensions | grep pluto
 
 ```bash
 # VS Code にインストール
-code --install-extension modern-pluto-client-0.0.1.vsix
+code --install-extension better-pluto-client-0.0.1.vsix
 ```
 
 ### アンインストール
 
 ```bash
 # Cursor からアンインストール
-cursor --uninstall-extension undefined_publisher.modern-pluto-client
+cursor --uninstall-extension undefined_publisher.better-pluto-client
 
 # VS Code からアンインストール
-code --uninstall-extension undefined_publisher.modern-pluto-client
+code --uninstall-extension undefined_publisher.better-pluto-client
 ```
 
 ### 開発中のデバッグ実行（推奨）
@@ -257,7 +257,7 @@ VSIX を作らずに素早くテストする場合：
 ### 動作確認
 
 1. `yarn compile` でビルド
-2. `npx vsce package && cursor --install-extension modern-pluto-client-0.0.1.vsix`
+2. `npx vsce package && cursor --install-extension better-pluto-client-0.0.1.vsix`
 3. Cursor を再起動
 4. `samples/Basic.jl` を開く
 5. セルの追加・削除・実行をテスト

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Modern Pluto Client
+# BetterPlutoClient
 
 A VS Code extension for editing Pluto.jl notebooks with **full native editor support**.
 


### PR DESCRIPTION
This PR updates the documentation files to reflect the new package name BetterPlutoClient.

## Changes
- Update README.md title from "Modern Pluto Client" to "BetterPlutoClient"
- Update CLAUDE.md title and all package name references
- Update installation/uninstallation commands to use `better-pluto-client`
- Add `PlutoUI.jl/` and `.DS_Store` to .gitignore

All documentation now consistently uses the BetterPlutoClient name.