### PR TITLE
Add cell folding and md"""...""" syntax support

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,12 @@
         "command": "pluto-notebook.saveAndExecute",
         "title": "Save and Execute Modified Cells",
         "category": "Pluto"
+      },
+      {
+        "command": "pluto-notebook.toggleCellFolded",
+        "title": "Toggle Cell Code Visibility (Fold/Unfold)",
+        "category": "Pluto",
+        "icon": "$(eye)"
       }
     ],
     "menus": {
@@ -116,6 +122,11 @@
           "command": "pluto-notebook.wrapInBeginEnd",
           "when": "notebookType == pluto-notebook && notebookCellType == code",
           "group": "inline@1"
+        },
+        {
+          "command": "pluto-notebook.toggleCellFolded",
+          "when": "notebookType == pluto-notebook",
+          "group": "inline@2"
         }
       ]
     },

--- a/src/PlutoNotebookController.ts
+++ b/src/PlutoNotebookController.ts
@@ -200,8 +200,10 @@ class PlutoKernel {
         const cellIds: string[] = [];
         const executions: Map<string, vscode.NotebookCellExecution> = new Map();
 
+        console.log(`[PlutoKernel] Batch: preparing ${cells.length} cells for execution`);
         // Prepare all cells: ensure IDs, create executions, update code
         for (const cell of cells) {
+            console.log(`[PlutoKernel] Batch: processing cell, content preview: ${cell.document.getText().slice(0, 50)}`);
             let cellId = getCellId(cell);
             if (!cellId) {
                 cellId = generateCellId();
@@ -215,7 +217,7 @@ class PlutoKernel {
                 this.cellExecutions.delete(cellId);
             }
 
-            // Create execution
+            // Create execution (for both code and markdown cells)
             const execution = this.controller.createNotebookCellExecution(cell);
             this.cellExecutions.set(cellId, execution);
             executions.set(cellId, execution);
@@ -225,7 +227,7 @@ class PlutoKernel {
 
             cellIds.push(cellId);
 
-            // Update cell code in Pluto
+            // Update cell code in Pluto (md"""...""" cells already have the wrapper)
             const code = cell.document.getText();
             console.log(`[PlutoKernel] Batch: updating cell ${cellId}`);
             await this.server.updateCell(cellId, code);
@@ -248,7 +250,7 @@ class PlutoKernel {
             await setCellId(cell, cellId);
         }
 
-        // Get cell code
+        // Get cell code (md"""...""" cells already have the wrapper)
         const code = cell.document.getText();
         console.log(`[PlutoKernel] executeCell called for ${cellId}, code: "${code.slice(0, 50)}..."`);
 
@@ -448,12 +450,17 @@ class PlutoKernel {
     private async syncCellsWithPluto(): Promise<void> {
         for (let i = 0; i < this.notebook.cellCount; i++) {
             const cell = this.notebook.cellAt(i);
+
             let cellId = getCellId(cell);
 
             if (!cellId) {
                 cellId = generateCellId();
                 await setCellId(cell, cellId);
             }
+
+            // Update cell code in Pluto (md"""...""" cells already have the wrapper)
+            const code = cell.document.getText();
+            await this.server.updateCell(cellId, code);
         }
     }
 
@@ -500,7 +507,7 @@ class PlutoKernel {
             } else {
                 existingOutput.body = state.output.body;
                 existingOutput.mime = state.output.mime;
-                console.log(`[PlutoKernel] Cell ${cellId} output: ${existingOutput.body?.slice(0, 100)}`);
+                console.log(`[PlutoKernel] Cell ${cellId} output - mime: ${state.output.mime}, body preview: ${existingOutput.body?.slice(0, 100)}`);
             }
         }
 
@@ -602,9 +609,16 @@ class PlutoKernel {
                     ]));
                 } catch {
                     outputs.push(new vscode.NotebookCellOutput([
-                        vscode.NotebookCellOutputItem.text(existingOutput.body, mime)
+                        vscode.NotebookCellOutputItem.text(existingOutput.body, 'text/plain')
                     ]));
                 }
+            } else if (mime === 'text/plain') {
+                // For text/plain, ensure proper HTML escaping for display
+                // VS Code's default renderer should handle this, but we ensure it's safe
+                console.log(`[PlutoKernel] Rendering text/plain output for cell ${cellId}, body length: ${existingOutput.body.length}, preview: ${JSON.stringify(existingOutput.body.substring(0, 100))}`);
+                outputs.push(new vscode.NotebookCellOutput([
+                    vscode.NotebookCellOutputItem.text(existingOutput.body, 'text/plain')
+                ]));
             } else {
                 outputs.push(new vscode.NotebookCellOutput([
                     vscode.NotebookCellOutputItem.text(existingOutput.body, mime)
@@ -758,6 +772,23 @@ class PlutoKernel {
                 } catch {
                     outputs.push(new vscode.NotebookCellOutput([
                         vscode.NotebookCellOutputItem.text(existingOutput.body, mime)
+                    ]));
+                }
+            } else if (mime === 'text/plain') {
+                // For text/plain, check if it's actually HTML content that was mislabeled
+                // (This can happen with md"""...""" cells when mime arrives before body)
+                if (existingOutput.body.trim().startsWith('<')) {
+                    console.log(`[PlutoKernel] Cell ${cellId} output looks like HTML, treating as HTML`);
+                    const plutoMime = existingOutput.body.includes('<bond')
+                        ? 'application/vnd.pluto.html+html'
+                        : 'text/html';
+                    outputs.push(new vscode.NotebookCellOutput([
+                        vscode.NotebookCellOutputItem.text(existingOutput.body, plutoMime)
+                    ]));
+                } else {
+                    console.log(`[PlutoKernel] Rendering text/plain output (direct update) for cell ${cellId}, body length: ${existingOutput.body.length}, preview: ${JSON.stringify(existingOutput.body.substring(0, 100))}`);
+                    outputs.push(new vscode.NotebookCellOutput([
+                        vscode.NotebookCellOutputItem.text(existingOutput.body, 'text/plain')
                     ]));
                 }
             } else {
@@ -1525,6 +1556,12 @@ export class PlutoNotebookController implements vscode.Disposable {
         notebook: vscode.NotebookDocument,
         _controller: vscode.NotebookController
     ): Promise<void> {
+        console.log(`[PlutoController] executeHandler called with ${cells.length} cells`);
+        for (let i = 0; i < cells.length; i++) {
+            const cell = cells[i];
+            console.log(`[PlutoController] Cell ${i}: content=${cell.document.getText().slice(0, 50)}`);
+        }
+
         const kernel = await this.getOrCreateKernel(notebook);
         await kernel.executeCells(cells);
     }

--- a/src/PlutoNotebookParser.ts
+++ b/src/PlutoNotebookParser.ts
@@ -5,19 +5,22 @@
 export interface PlutoCell {
     id: string;
     code: string;
+    kind: 'code' | 'markdown';
+    folded: boolean;
 }
 
 export interface PlutoNotebook {
     version: string;
     cells: Map<string, PlutoCell>;
     cellOrder: string[];
+    foldedCells: Set<string>;  // Track which cells are folded
     preamble: string;
 }
 
 const CELL_MARKER = /^# ╔═╡ ([0-9a-f-]+)$/;
 const CELL_ORDER_START = /^# ╔═╡ Cell order:$/;
-// Cell order uses ╠═ for visible cells or ╟═ for hidden cells
-const CELL_ORDER_ITEM = /^# [╠╟]═([0-9a-f-]+)$/;
+// Cell order uses ╠═ for visible cells or ╟─ for hidden (folded) cells
+const CELL_ORDER_ITEM = /^# ([╠╟])[═─]([0-9a-f-]+)$/;
 const VERSION_PATTERN = /^# v(\d+\.\d+\.\d+)$/;
 
 /**
@@ -29,6 +32,7 @@ export function parse(content: string): PlutoNotebook {
     let version = '0.20.0';
     const cells = new Map<string, PlutoCell>();
     const cellOrder: string[] = [];
+    const foldedCells = new Set<string>();
     const preambleLines: string[] = [];
 
     let currentCellId: string | null = null;
@@ -53,9 +57,14 @@ export function parse(content: string): PlutoNotebook {
         if (CELL_ORDER_START.test(line)) {
             // Save current cell if any
             if (currentCellId) {
+                const cellCode = currentCellLines.join('\n').trim();
+                const cellKind = detectCellKind(cellCode);
+                // Keep md"""...""" syntax as-is (don't extract content)
                 cells.set(currentCellId, {
                     id: currentCellId,
-                    code: currentCellLines.join('\n').trim()
+                    code: cellCode,
+                    kind: cellKind,
+                    folded: false  // Will be updated later from cell order
                 });
             }
             inCellOrder = true;
@@ -65,7 +74,13 @@ export function parse(content: string): PlutoNotebook {
         if (inCellOrder) {
             const orderMatch = line.match(CELL_ORDER_ITEM);
             if (orderMatch) {
-                cellOrder.push(orderMatch[1]);
+                const delimiter = orderMatch[1];  // ╠ or ╟
+                const cellId = orderMatch[2];
+                cellOrder.push(cellId);
+                // ╟─ means folded (hidden code)
+                if (delimiter === '╟') {
+                    foldedCells.add(cellId);
+                }
             }
             continue;
         }
@@ -75,9 +90,14 @@ export function parse(content: string): PlutoNotebook {
         if (cellMatch) {
             // Save previous cell
             if (currentCellId) {
+                const cellCode = currentCellLines.join('\n').trim();
+                const cellKind = detectCellKind(cellCode);
+                // Keep md"""...""" syntax as-is (don't extract content)
                 cells.set(currentCellId, {
                     id: currentCellId,
-                    code: currentCellLines.join('\n').trim()
+                    code: cellCode,
+                    kind: cellKind,
+                    folded: false  // Will be updated later from cell order
                 });
             } else if (inPreamble) {
                 inPreamble = false;
@@ -98,16 +118,27 @@ export function parse(content: string): PlutoNotebook {
 
     // Save last cell if not in cell order
     if (currentCellId && !inCellOrder) {
+        const cellCode = currentCellLines.join('\n').trim();
+        const cellKind = detectCellKind(cellCode);
+        // Keep md"""...""" syntax as-is (don't extract content)
         cells.set(currentCellId, {
             id: currentCellId,
-            code: currentCellLines.join('\n').trim()
+            code: cellCode,
+            kind: cellKind,
+            folded: false  // Will be updated later from cell order
         });
+    }
+
+    // Update cells with folded state
+    for (const [id, cell] of cells) {
+        cell.folded = foldedCells.has(id);
     }
 
     return {
         version,
         cells,
         cellOrder,
+        foldedCells,
         preamble: preambleLines.join('\n').trim()
     };
 }
@@ -132,17 +163,72 @@ export function serialize(notebook: PlutoNotebook): string {
     // Cells
     for (const [id, cell] of notebook.cells) {
         lines.push(`# ╔═╡ ${id}`);
-        lines.push(cell.code);
+        // Code is stored as-is (md"""...""" cells already have the wrapper)
+        // Remove leading newline if it was added for folding display
+        let code = cell.code;
+        if (cell.folded && code.startsWith('\n')) {
+            code = code.substring(1);
+        }
+        lines.push(code);
         lines.push('');
     }
 
     // Cell order
     lines.push('# ╔═╡ Cell order:');
     for (const id of notebook.cellOrder) {
-        lines.push(`# ╠═${id}`);
+        const cell = notebook.cells.get(id);
+        // Use ╟─ for folded cells, ╠═ for visible cells
+        const delimiter = cell?.folded ? '# ╟─' : '# ╠═';
+        lines.push(`${delimiter}${id}`);
     }
 
     return lines.join('\n');
+}
+
+/**
+ * Detect if a cell is a Markdown cell (starts with md""")
+ */
+export function detectCellKind(code: string): 'code' | 'markdown' {
+    const trimmed = code.trim();
+    // Check if code starts with md""" (possibly with whitespace)
+    return trimmed.startsWith('md"""') ? 'markdown' : 'code';
+}
+
+/**
+ * Extract Markdown content from md"""...""" wrapper
+ * Handles both single-line and multi-line cases
+ */
+function extractMarkdownContent(code: string): string {
+    const trimmed = code.trim();
+    if (!trimmed.startsWith('md"""')) {
+        return code;
+    }
+
+    // Find the opening md"""
+    const startIdx = trimmed.indexOf('md"""');
+    if (startIdx === -1) {
+        return code;
+    }
+
+    // Find the closing """
+    // Start searching after md"""
+    let searchStart = startIdx + 5;
+    let endIdx = trimmed.indexOf('"""', searchStart);
+
+    // If not found, try to find it at the end
+    if (endIdx === -1) {
+        if (trimmed.endsWith('"""')) {
+            endIdx = trimmed.length - 3;
+        } else {
+            // No closing found, return as-is
+            return code;
+        }
+    }
+
+    // Extract content between md""" and """
+    const content = trimmed.substring(startIdx + 5, endIdx);
+
+    return content;
 }
 
 /**

--- a/src/PlutoNotebookSerializer.ts
+++ b/src/PlutoNotebookSerializer.ts
@@ -17,6 +17,7 @@ interface PlutoNotebookMetadata {
 
 interface PlutoCellMetadata {
     id: string;
+    folded?: boolean;  // Code is hidden (folded) in Pluto.jl
 }
 
 /**
@@ -94,16 +95,26 @@ export class PlutoNotebookSerializer implements vscode.NotebookSerializer {
             const cell = notebook.cells.get(cellId);
             if (!cell) continue;
 
+            // All cells are Code cells in Pluto.jl (including md"""...""" cells)
+            // Markdown cells use md"""...""" syntax which is Julia code
+            // For folded cells, add leading newline so the collapsed preview is empty
+            let code = cell.code;
+            if (cell.folded && !code.startsWith('\n')) {
+                code = '\n' + code;
+            }
             const cellData = new vscode.NotebookCellData(
                 vscode.NotebookCellKind.Code,
-                cell.code,
+                code,
                 JULIA_LANGUAGE_ID
             );
 
-            // Store cell ID in metadata
+            // Store cell ID and folded state in metadata
+            // Use inputCollapsed to visually hide the cell input when folded
             cellData.metadata = {
+                inputCollapsed: cell.folded,  // VS Code native property to collapse input
                 custom: {
-                    id: cellId
+                    id: cellId,
+                    folded: cell.folded
                 } as PlutoCellMetadata
             };
 
@@ -119,7 +130,8 @@ export class PlutoNotebookSerializer implements vscode.NotebookSerializer {
             );
             emptyCell.metadata = {
                 custom: {
-                    id: parser.generateCellId()
+                    id: parser.generateCellId(),
+                    folded: false
                 } as PlutoCellMetadata
             };
             cells.push(emptyCell);
@@ -146,6 +158,7 @@ export class PlutoNotebookSerializer implements vscode.NotebookSerializer {
 
         const cells = new Map<string, parser.PlutoCell>();
         const cellOrder: string[] = [];
+        const foldedCells = new Set<string>();
 
         for (const cellData of data.cells) {
             const cellMetadata = (cellData.metadata?.custom || {}) as PlutoCellMetadata;
@@ -156,10 +169,22 @@ export class PlutoNotebookSerializer implements vscode.NotebookSerializer {
                 cellId = parser.generateCellId();
             }
 
+            // All cells are Code cells - detect markdown by md"""...""" syntax
+            const code = cellData.value;
+            const cellKind = parser.detectCellKind(code);
+            // Check both inputCollapsed (VS Code native) and custom.folded
+            const folded = cellData.metadata?.inputCollapsed ?? cellMetadata.folded ?? false;
+
             cells.set(cellId, {
                 id: cellId,
-                code: cellData.value
+                code: code,
+                kind: cellKind,
+                folded: folded
             });
+
+            if (folded) {
+                foldedCells.add(cellId);
+            }
 
             cellOrder.push(cellId);
         }
@@ -168,6 +193,7 @@ export class PlutoNotebookSerializer implements vscode.NotebookSerializer {
             version: metadata.version || '0.20.0',
             cells,
             cellOrder,
+            foldedCells,
             preamble: metadata.preamble || ''
         };
     }
@@ -183,7 +209,7 @@ export class PlutoNotebookSerializer implements vscode.NotebookSerializer {
             JULIA_LANGUAGE_ID
         );
         cell.metadata = {
-            custom: { id: cellId } as PlutoCellMetadata
+            custom: { id: cellId, folded: false } as PlutoCellMetadata
         };
 
         const notebookData = new vscode.NotebookData([cell]);
@@ -208,7 +234,7 @@ export class PlutoNotebookSerializer implements vscode.NotebookSerializer {
             JULIA_LANGUAGE_ID
         );
         cell.metadata = {
-            custom: { id: cellId } as PlutoCellMetadata
+            custom: { id: cellId, folded: false } as PlutoCellMetadata
         };
 
         const notebookData = new vscode.NotebookData([cell]);
@@ -249,4 +275,74 @@ export async function setCellId(cell: vscode.NotebookCell, cellId: string): Prom
     ]);
 
     await vscode.workspace.applyEdit(edit);
+}
+
+/**
+ * Get folded state from cell metadata
+ */
+export function isCellFolded(cell: vscode.NotebookCell): boolean {
+    // Check both inputCollapsed (VS Code native) and custom.folded
+    if (cell.metadata?.inputCollapsed !== undefined) {
+        return cell.metadata.inputCollapsed;
+    }
+    const metadata = cell.metadata?.custom as PlutoCellMetadata | undefined;
+    return metadata?.folded ?? false;
+}
+
+/**
+ * Set folded state in cell metadata
+ */
+export async function setCellFolded(cell: vscode.NotebookCell, folded: boolean): Promise<void> {
+    const edit = new vscode.WorkspaceEdit();
+    const newMetadata = {
+        ...cell.metadata,
+        inputCollapsed: folded,  // VS Code native property to collapse input
+        custom: {
+            ...(cell.metadata?.custom || {}),
+            folded: folded
+        }
+    };
+
+    edit.set(cell.notebook.uri, [
+        vscode.NotebookEdit.updateCellMetadata(cell.index, newMetadata)
+    ]);
+
+    await vscode.workspace.applyEdit(edit);
+}
+
+/**
+ * Toggle folded state of a cell
+ */
+export async function toggleCellFolded(cell: vscode.NotebookCell): Promise<boolean> {
+    const currentFolded = isCellFolded(cell);
+    const newFolded = !currentFolded;
+
+    // Get current cell content
+    const currentCode = cell.document.getText();
+
+    const edit = new vscode.WorkspaceEdit();
+
+    if (newFolded) {
+        // When folding: add empty line at the beginning so the preview shows empty
+        if (!currentCode.startsWith('\n')) {
+            const fullRange = new vscode.Range(
+                cell.document.positionAt(0),
+                cell.document.positionAt(currentCode.length)
+            );
+            edit.replace(cell.document.uri, fullRange, '\n' + currentCode);
+        }
+    } else {
+        // When unfolding: remove the leading empty line if it was added
+        if (currentCode.startsWith('\n')) {
+            const fullRange = new vscode.Range(
+                cell.document.positionAt(0),
+                cell.document.positionAt(currentCode.length)
+            );
+            edit.replace(cell.document.uri, fullRange, currentCode.substring(1));
+        }
+    }
+
+    await vscode.workspace.applyEdit(edit);
+    await setCellFolded(cell, newFolded);
+    return newFolded;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,7 +9,7 @@
  */
 
 import * as vscode from 'vscode';
-import { PlutoNotebookSerializer } from './PlutoNotebookSerializer';
+import { PlutoNotebookSerializer, isCellFolded, toggleCellFolded } from './PlutoNotebookSerializer';
 import { PlutoNotebookController } from './PlutoNotebookController';
 
 const NOTEBOOK_TYPE = 'pluto-notebook';
@@ -43,8 +43,6 @@ export function activate(context: vscode.ExtensionContext) {
 
     // Setup renderer messaging for interactive widgets (Slider, etc.)
     setupRendererMessaging(context);
-
-    console.log('[PlutoExtension] Extension activation complete');
 
     // Register commands
     context.subscriptions.push(
@@ -171,6 +169,71 @@ export function activate(context: vscode.ExtensionContext) {
             vscode.window.showInformationMessage('Cell wrapped in begin...end');
         })
     );
+
+    // Command to toggle cell code visibility (fold/unfold)
+    context.subscriptions.push(
+        vscode.commands.registerCommand('pluto-notebook.toggleCellFolded', async (cellArg?: vscode.NotebookCell | { cell?: vscode.NotebookCell }) => {
+            console.log('[PlutoExtension] toggleCellFolded called with arg:', cellArg);
+
+            // If called from cell title bar, the argument is the cell directly or {cell: ...}
+            let targetCell: vscode.NotebookCell | undefined;
+            if (cellArg) {
+                if ('document' in cellArg && 'index' in cellArg) {
+                    // It's a NotebookCell directly
+                    targetCell = cellArg as vscode.NotebookCell;
+                } else if ('cell' in cellArg && cellArg.cell) {
+                    // It's {cell: NotebookCell}
+                    targetCell = cellArg.cell;
+                }
+            }
+
+            if (targetCell) {
+                // Update our custom metadata for file saving
+                const newFolded = await toggleCellFolded(targetCell);
+                console.log(`[PlutoExtension] Cell ${targetCell.index} folded: ${newFolded}`);
+
+                // Use VS Code's built-in collapse command for visual effect
+                // First, select the cell
+                const notebookEditor = vscode.window.activeNotebookEditor;
+                if (notebookEditor) {
+                    // Select the cell
+                    notebookEditor.selection = new vscode.NotebookRange(targetCell.index, targetCell.index + 1);
+
+                    // Use VS Code's built-in command to toggle collapse
+                    if (newFolded) {
+                        await vscode.commands.executeCommand('notebook.cell.collapseCellInput');
+                    } else {
+                        await vscode.commands.executeCommand('notebook.cell.expandCellInput');
+                    }
+                }
+                return;
+            }
+
+            // Otherwise, use selection
+            const notebookEditor = vscode.window.activeNotebookEditor;
+            if (!notebookEditor) {
+                vscode.window.showErrorMessage('No active notebook');
+                return;
+            }
+
+            const selections = notebookEditor.selections;
+            if (selections.length === 0) {
+                vscode.window.showErrorMessage('No cell selected');
+                return;
+            }
+
+            // Toggle folded state for all selected cells
+            for (const cellRange of selections) {
+                for (let i = cellRange.start; i < cellRange.end; i++) {
+                    const cell = notebookEditor.notebook.cellAt(i);
+                    const newFolded = await toggleCellFolded(cell);
+                    console.log(`[PlutoExtension] Cell ${i} folded: ${newFolded}`);
+                }
+            }
+        })
+    );
+
+    console.log('[PlutoExtension] Extension activation complete');
 }
 
 /**


### PR DESCRIPTION
## Summary

- Implement cell folding (`code_folded`) feature matching Pluto.jl behavior
- Handle Markdown cells as Julia code with `md"""..."""` syntax
- Ensure compatibility with Pluto.jl notebook file format

## Changes

### Cell Folding Feature
- Parse `╟─` delimiter for folded cells in Cell order section
- Serialize folded cells with `╟─` delimiter  
- Add toggle command with eye icon in cell title bar
- Use VS Code's built-in collapse commands for visual folding
- Add leading newline trick for empty collapse preview

### Markdown Cell Handling
- All cells are Code cells (matching Pluto.jl's actual format)
- Detect markdown cells by `md"""` prefix
- Variable interpolation (`$x`) is evaluated by Pluto.jl kernel

### Metadata Persistence
- Store `inputCollapsed` for VS Code visual state
- Store `custom.folded` for Pluto.jl file format compatibility

## Test plan

- [ ] Open a Pluto.jl notebook with folded cells (`╟─` in Cell order)
- [ ] Verify folded cells show collapsed input on load
- [ ] Click eye icon to toggle cell folding
- [ ] Save notebook and verify `╟─` delimiter is written for folded cells
- [ ] Test `md"""..."""` cells with variable interpolation (`$x`)
- [ ] Reload window and verify folded state persists


Made with [Cursor](https://cursor.com)