### PR TITLE
Apply cell folding when notebook opens instead of kernel start

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -44,13 +44,38 @@ export function activate(context: vscode.ExtensionContext) {
     // Setup renderer messaging for interactive widgets (Slider, etc.)
     setupRendererMessaging(context);
 
-    // Track which notebooks have had folded states applied (only apply once per kernel start)
-    const foldedNotebooks = new Set<string>();
+    // Apply folded state when notebook editor becomes active
+    // Track which notebooks have been processed to avoid re-applying
+    const processedNotebooks = new Set<string>();
+
+    context.subscriptions.push(
+        vscode.window.onDidChangeActiveNotebookEditor(async (editor) => {
+            if (!editor) {
+                return;
+            }
+            const notebook = editor.notebook;
+            if (notebook.notebookType !== NOTEBOOK_TYPE) {
+                return;
+            }
+
+            // Only apply once per notebook
+            const notebookKey = notebook.uri.toString();
+            if (processedNotebooks.has(notebookKey)) {
+                return;
+            }
+            processedNotebooks.add(notebookKey);
+
+            console.log('[PlutoExtension] Notebook editor activated, applying folded states...');
+            // Small delay to ensure the editor is fully ready
+            await new Promise(resolve => setTimeout(resolve, 100));
+            await applyFoldedStates(notebook);
+        })
+    );
 
     // Clean up when notebook is closed
     context.subscriptions.push(
         vscode.workspace.onDidCloseNotebookDocument((notebook) => {
-            foldedNotebooks.delete(notebook.uri.toString());
+            processedNotebooks.delete(notebook.uri.toString());
         })
     );
 
@@ -83,16 +108,6 @@ export function activate(context: vscode.ExtensionContext) {
                 }, async () => {
                     await controller!.startKernel(notebook);
                 });
-
-                // Apply folded states after kernel starts (security: show all cells first, then fold)
-                // This matches Pluto.jl's behavior where folded cells are collapsed after trust is established
-                const notebookKey = notebook.uri.toString();
-                if (!foldedNotebooks.has(notebookKey)) {
-                    foldedNotebooks.add(notebookKey);
-                    console.log('[PlutoExtension] Kernel started, applying folded states...');
-                    await new Promise(resolve => setTimeout(resolve, 100));
-                    await applyFoldedStates(notebook);
-                }
             }
         })
     );


### PR DESCRIPTION
## Summary
- Move cell folding logic from kernel start to notebook open event
- Cells marked with `╟─` are now collapsed immediately when the notebook is opened
- Provides better UX by showing the intended view without requiring kernel start

## Test plan
- [ ] Open a Pluto notebook with folded cells (╟─ markers in cell order section)
- [ ] Verify folded cells are collapsed immediately when notebook opens
- [ ] Verify folding state persists correctly when saving the notebook

Made with [Cursor](https://cursor.com)