### PR TITLE
improve: disable formatOnSave and rename output channel

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,6 @@
 		"dist": true // set this to false to include "dist" folder in search results
 	},
 	// Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-	"typescript.tsc.autoDetect": "off"
+	"typescript.tsc.autoDetect": "off",
+	"editor.formatOnSave": false,
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -37,7 +37,7 @@ export function log(message: string): void {
 
 export function activate(context: vscode.ExtensionContext) {
     // Create output channel first
-    outputChannel = vscode.window.createOutputChannel('BetterPluto');
+    outputChannel = vscode.window.createOutputChannel('BetterPlutoClient');
     context.subscriptions.push(outputChannel);
 
     log('========================================');


### PR DESCRIPTION
## Summary
- Disable `editor.formatOnSave` in workspace settings to prevent unnecessary formatting prompts when saving `.jl` files
- Rename output channel from 'BetterPluto' to 'BetterPlutoClient' for consistency with extension name

## Test plan
- [x] Verify no "Running Code Actions and Formatters..." message appears when saving .jl files
- [x] Verify output channel is renamed in VS Code Output panel

Made with [Cursor](https://cursor.com)