### PR TITLE
fix: remove newline hack from toggle cell fold

### DIFF
--- a/src/PlutoNotebookParser.ts
+++ b/src/PlutoNotebookParser.ts
@@ -194,11 +194,7 @@ export function serialize(notebook: PlutoNotebook): string {
     for (const [id, cell] of notebook.cells) {
         lines.push(`# ╔═╡ ${id}`);
         // Code is stored as-is (md"""...""" cells already have the wrapper)
-        // Remove leading newline if it was added for folding display
-        let code = cell.code;
-        if (cell.folded && code.startsWith('\n')) {
-            code = code.substring(1);
-        }
+        const code = cell.code;
         lines.push(code);
         lines.push('');
     }

--- a/src/PlutoNotebookSerializer.ts
+++ b/src/PlutoNotebookSerializer.ts
@@ -98,11 +98,7 @@ export class PlutoNotebookSerializer implements vscode.NotebookSerializer {
 
             // All cells are Code cells in Pluto.jl (including md"""...""" cells)
             // Markdown cells use md"""...""" syntax which is Julia code
-            // For folded cells, add leading newline so the collapsed preview is empty
-            let code = cell.code;
-            if (cell.folded && !code.startsWith('\n')) {
-                code = '\n' + code;
-            }
+            const code = cell.code;
             const cellData = new vscode.NotebookCellData(
                 vscode.NotebookCellKind.Code,
                 code,
@@ -332,32 +328,6 @@ export async function toggleCellFolded(cell: vscode.NotebookCell): Promise<boole
     const currentFolded = isCellFolded(cell);
     const newFolded = !currentFolded;
 
-    // Get current cell content
-    const currentCode = cell.document.getText();
-
-    const edit = new vscode.WorkspaceEdit();
-
-    if (newFolded) {
-        // When folding: add empty line at the beginning so the preview shows empty
-        if (!currentCode.startsWith('\n')) {
-            const fullRange = new vscode.Range(
-                cell.document.positionAt(0),
-                cell.document.positionAt(currentCode.length)
-            );
-            edit.replace(cell.document.uri, fullRange, '\n' + currentCode);
-        }
-    } else {
-        // When unfolding: remove the leading empty line if it was added
-        if (currentCode.startsWith('\n')) {
-            const fullRange = new vscode.Range(
-                cell.document.positionAt(0),
-                cell.document.positionAt(currentCode.length)
-            );
-            edit.replace(cell.document.uri, fullRange, currentCode.substring(1));
-        }
-    }
-
-    await vscode.workspace.applyEdit(edit);
     await setCellFolded(cell, newFolded);
     return newFolded;
 }


### PR DESCRIPTION
## Summary
- Remove the `\n` hack from toggle cell code visibility that caused spurious cell re-execution
- `toggleCellFolded()` now only updates metadata (`inputCollapsed` + `custom.folded`) without modifying cell content
- VS Code's native `notebook.cell.collapseCellInput`/`expandCellInput` commands handle the visual state

## Problem
The previous implementation modified cell content by prepending `\n` to folded cells to make the collapsed preview appear blank. This caused:
- `onDidChangeNotebookDocument` firing with `cellChange.document` set
- Cells being added to `modifiedCellIds` even though user code didn't change
- Spurious re-execution on Cmd+S with potentially corrupted code (leading `\n`)

## Test plan
- [ ] Open a `.jl` file with folded cells (`╟─` markers) — verify cells appear collapsed
- [ ] Toggle fold/unfold via eye icon — verify code stays intact
- [ ] With kernel running, fold a cell then Cmd+S — verify NO cells re-execute (check BetterPlutoClient output channel)
- [ ] Save and re-open — verify folded state persists and `.jl` file has no `\n` prefix in cell bodies

🤖 Generated with [Claude Code](https://claude.ai/code)