### PR TITLE
docs: add limitation about collapsed cell preview behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ Or use the command palette:
 
 This extension reads and writes standard Pluto.jl notebook files (`.jl`), which are valid Julia scripts and can be run directly.
 
+## Limitations
+
+- **Collapsed cell preview**: When a cell is folded (code hidden), VS Code shows the first line of code as a preview. This is VS Code's default behavior and cannot be customized. In Pluto.jl browser UI, folded cells show no preview.
+
 ## Known Issues
 
 - First cell execution starts the Pluto kernel (takes ~30-60 seconds on first run)


### PR DESCRIPTION
## Summary
- Add Limitations section to README.md
- Document that VS Code shows the first line of code as a preview when cells are folded
- This is VS Code's default notebook behavior and cannot be customized

## Context
After removing the `\n` hack in PR #31, collapsed cells now show their first line of code as a preview. This is standard VS Code notebook behavior, unlike Pluto.jl's browser UI which hides the preview entirely.

## Test plan
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.ai/code)