### PR TITLE
fix: restore newline hack for collapsed cells with skip flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,10 +104,6 @@ Or use the command palette:
 
 This extension reads and writes standard Pluto.jl notebook files (`.jl`), which are valid Julia scripts and can be run directly.
 
-## Limitations
-
-- **Collapsed cell preview**: When a cell is folded (code hidden), VS Code shows the first line of code as a preview. This is VS Code's default behavior and cannot be customized. In Pluto.jl browser UI, folded cells show no preview.
-
 ## Known Issues
 
 - First cell execution starts the Pluto kernel (takes ~30-60 seconds on first run)

--- a/src/PlutoNotebookController.ts
+++ b/src/PlutoNotebookController.ts
@@ -410,6 +410,21 @@ class PlutoKernel {
     // Track cells that have been modified since last save
     private modifiedCellIds = new Set<string>();
 
+    // Track cells that are being folded/unfolded (changes should be ignored)
+    private foldChangingCellIds = new Set<string>();
+
+    /**
+     * Mark a cell as undergoing fold/unfold change.
+     * Changes to this cell will be ignored in modifiedCellIds.
+     */
+    markCellAsFoldChanging(cellId: string): void {
+        this.foldChangingCellIds.add(cellId);
+        // Auto-clear after a short delay to handle any edge cases
+        setTimeout(() => {
+            this.foldChangingCellIds.delete(cellId);
+        }, 500);
+    }
+
     /**
      * Handle notebook changes (cell added/removed/reordered/modified)
      */
@@ -451,10 +466,11 @@ class PlutoKernel {
         }
 
         // Track cell content changes (for Cmd+S execution)
+        // Skip cells that are being folded/unfolded (their \n changes should not trigger re-execution)
         for (const cellChange of e.cellChanges) {
             if (cellChange.document) {
                 const cellId = getCellId(cellChange.cell);
-                if (cellId) {
+                if (cellId && !this.foldChangingCellIds.has(cellId)) {
                     this.modifiedCellIds.add(cellId);
                 }
             }
@@ -1941,6 +1957,18 @@ export class PlutoNotebookController implements vscode.Disposable {
             }
         }
         vscode.commands.executeCommand('setContext', 'pluto.kernelRunning', anyRunning);
+    }
+
+    /**
+     * Mark a cell as undergoing fold/unfold change.
+     * Changes to this cell will be ignored in modifiedCellIds to prevent spurious re-execution.
+     */
+    markCellAsFoldChanging(notebook: vscode.NotebookDocument, cellId: string): void {
+        const key = notebook.uri.toString();
+        const kernel = this.kernels.get(key);
+        if (kernel) {
+            kernel.markCellAsFoldChanging(cellId);
+        }
     }
 
     dispose(): void {

--- a/src/PlutoNotebookParser.ts
+++ b/src/PlutoNotebookParser.ts
@@ -194,7 +194,11 @@ export function serialize(notebook: PlutoNotebook): string {
     for (const [id, cell] of notebook.cells) {
         lines.push(`# ╔═╡ ${id}`);
         // Code is stored as-is (md"""...""" cells already have the wrapper)
-        const code = cell.code;
+        // Remove leading newline if it was added for folding display
+        let code = cell.code;
+        if (cell.folded && code.startsWith('\n')) {
+            code = code.substring(1);
+        }
         lines.push(code);
         lines.push('');
     }

--- a/src/PlutoNotebookSerializer.ts
+++ b/src/PlutoNotebookSerializer.ts
@@ -98,7 +98,11 @@ export class PlutoNotebookSerializer implements vscode.NotebookSerializer {
 
             // All cells are Code cells in Pluto.jl (including md"""...""" cells)
             // Markdown cells use md"""...""" syntax which is Julia code
-            const code = cell.code;
+            // For folded cells, add leading newline so the collapsed preview is empty
+            let code = cell.code;
+            if (cell.folded && !code.startsWith('\n')) {
+                code = '\n' + code;
+            }
             const cellData = new vscode.NotebookCellData(
                 vscode.NotebookCellKind.Code,
                 code,
@@ -323,11 +327,40 @@ export async function setCellFolded(cell: vscode.NotebookCell, folded: boolean):
 
 /**
  * Toggle folded state of a cell
+ * Adds/removes leading newline to make collapsed preview appear empty.
+ * The caller should mark the cell as fold-changing via PlutoNotebookController.markCellAsFoldChanging()
+ * to prevent the content change from triggering re-execution on Cmd+S.
  */
 export async function toggleCellFolded(cell: vscode.NotebookCell): Promise<boolean> {
     const currentFolded = isCellFolded(cell);
     const newFolded = !currentFolded;
 
+    // Get current cell content
+    const currentCode = cell.document.getText();
+
+    const edit = new vscode.WorkspaceEdit();
+
+    if (newFolded) {
+        // When folding: add empty line at the beginning so the preview shows empty
+        if (!currentCode.startsWith('\n')) {
+            const fullRange = new vscode.Range(
+                cell.document.positionAt(0),
+                cell.document.positionAt(currentCode.length)
+            );
+            edit.replace(cell.document.uri, fullRange, '\n' + currentCode);
+        }
+    } else {
+        // When unfolding: remove the leading empty line if it was added
+        if (currentCode.startsWith('\n')) {
+            const fullRange = new vscode.Range(
+                cell.document.positionAt(0),
+                cell.document.positionAt(currentCode.length)
+            );
+            edit.replace(cell.document.uri, fullRange, currentCode.substring(1));
+        }
+    }
+
+    await vscode.workspace.applyEdit(edit);
     await setCellFolded(cell, newFolded);
     return newFolded;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,7 +9,7 @@
  */
 
 import * as vscode from 'vscode';
-import { PlutoNotebookSerializer, isCellFolded, toggleCellFolded } from './PlutoNotebookSerializer';
+import { PlutoNotebookSerializer, isCellFolded, toggleCellFolded, getCellId } from './PlutoNotebookSerializer';
 import { PlutoNotebookController } from './PlutoNotebookController';
 
 const NOTEBOOK_TYPE = 'pluto-notebook';
@@ -246,6 +246,12 @@ export function activate(context: vscode.ExtensionContext) {
             }
 
             if (targetCell) {
+                // Mark cell as fold-changing to prevent the \n change from triggering re-execution
+                const cellId = getCellId(targetCell);
+                if (cellId && controller) {
+                    controller.markCellAsFoldChanging(targetCell.notebook, cellId);
+                }
+
                 // Update our custom metadata for file saving
                 const newFolded = await toggleCellFolded(targetCell);
                 log(`Cell ${targetCell.index} folded: ${newFolded}`);
@@ -284,6 +290,11 @@ export function activate(context: vscode.ExtensionContext) {
             for (const cellRange of selections) {
                 for (let i = cellRange.start; i < cellRange.end; i++) {
                     const cell = notebookEditor.notebook.cellAt(i);
+                    // Mark cell as fold-changing to prevent the \n change from triggering re-execution
+                    const cellId = getCellId(cell);
+                    if (cellId && controller) {
+                        controller.markCellAsFoldChanging(notebookEditor.notebook, cellId);
+                    }
                     const newFolded = await toggleCellFolded(cell);
                     log(`Cell ${i} folded: ${newFolded}`);
                 }


### PR DESCRIPTION
## Summary
- Restore the `\n` hack for collapsed cells to show empty preview (like Pluto.jl browser UI)
- Add mechanism to prevent fold/unfold from triggering re-execution on Cmd+S
- Remove the "Limitations" section from README (no longer applicable)

## Problem
PR #31 removed the newline hack, causing collapsed cells to show the first line of code as preview. Users wanted the Pluto.jl-like behavior where folded cells show no preview.

## Solution
Restore the `\n` hack with a skip flag mechanism:
1. Add `foldChangingCellIds` set in `PlutoKernel` to track cells being folded
2. Add `markCellAsFoldChanging()` method to mark cells before toggling
3. Skip adding fold-changing cells to `modifiedCellIds` in `handleNotebookChange`
4. Call `markCellAsFoldChanging` before `toggleCellFolded` in `extension.ts`

## Test plan
- [ ] Open a notebook and fold a cell - verify preview shows empty
- [ ] Unfold the cell - verify code is intact (no leading `\n`)
- [ ] With kernel running, fold/unfold a cell then Cmd+S - verify NO cells re-execute
- [ ] Save notebook, re-open - verify folded state persists correctly

🤖 Generated with [Claude Code](https://claude.ai/code)