### PR TITLE
test(pluto-notebook-parser): add internal cells test suite

### DIFF
--- a/src/test/pluto-notebook-parser.test.ts
+++ b/src/test/pluto-notebook-parser.test.ts
@@ -2,6 +2,7 @@ import * as assert from 'assert';
 import {
     parse,
     serialize,
+    isPlutoInternalCell,
     detectCellKind,
     generateCellId,
     type PlutoNotebook
@@ -93,5 +94,147 @@ suite('PlutoNotebookParser', () => {
     test('generateCellId: returns uuid-like v4 id', () => {
         const id = generateCellId();
         assert.ok(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(id));
+    });
+});
+
+const NOTEBOOK_WITH_INTERNAL_CELLS = `### A Pluto.jl notebook ###
+# v0.20.19
+
+using Markdown
+using InteractiveUtils
+
+# ╔═╡ abcdef01-1234-5678-abcd-ef0123456789
+1 + 1
+
+# ╔═╡ 00000000-0000-0000-0000-000000000001
+PLUTO_PROJECT_TOML_CONTENTS = """
+[deps]
+Example = "7876af07-990d-54b4-ab0e-23690620f79a"
+"""
+
+# ╔═╡ 00000000-0000-0000-0000-000000000002
+PLUTO_MANIFEST_TOML_CONTENTS = """
+# This file is machine-generated
+[[deps.Example]]
+git-tree-sha1 = "abc123"
+uuid = "7876af07-990d-54b4-ab0e-23690620f79a"
+version = "0.5.3"
+"""
+
+# ╔═╡ Cell order:
+# ╠═abcdef01-1234-5678-abcd-ef0123456789
+# ╟─00000000-0000-0000-0000-000000000001
+# ╟─00000000-0000-0000-0000-000000000002`;
+
+const NOTEBOOK_WITHOUT_INTERNAL_CELLS = `### A Pluto.jl notebook ###
+# v0.20.19
+
+using Markdown
+using InteractiveUtils
+
+# ╔═╡ abcdef01-1234-5678-abcd-ef0123456789
+1 + 1
+
+# ╔═╡ Cell order:
+# ╠═abcdef01-1234-5678-abcd-ef0123456789`;
+
+suite('PlutoNotebookParser - internal cells', () => {
+    test('isPlutoInternalCell: recognizes known internal IDs', () => {
+        assert.strictEqual(isPlutoInternalCell('00000000-0000-0000-0000-000000000001'), true);
+        assert.strictEqual(isPlutoInternalCell('00000000-0000-0000-0000-000000000002'), true);
+        assert.strictEqual(isPlutoInternalCell('abcdef01-1234-5678-abcd-ef0123456789'), false);
+    });
+
+    test('parse collects internal cells into internalCells map', () => {
+        const notebook = parse(NOTEBOOK_WITH_INTERNAL_CELLS);
+        assert.strictEqual(notebook.internalCells.size, 2);
+        assert.ok(notebook.internalCells.has('00000000-0000-0000-0000-000000000001'));
+        assert.ok(notebook.internalCells.has('00000000-0000-0000-0000-000000000002'));
+
+        const projectToml = notebook.internalCells.get('00000000-0000-0000-0000-000000000001') || '';
+        assert.ok(projectToml.includes('PLUTO_PROJECT_TOML_CONTENTS'));
+        assert.ok(projectToml.includes('Example'));
+
+        const manifestToml = notebook.internalCells.get('00000000-0000-0000-0000-000000000002') || '';
+        assert.ok(manifestToml.includes('PLUTO_MANIFEST_TOML_CONTENTS'));
+        assert.ok(manifestToml.includes('0.5.3'));
+    });
+
+    test('parse excludes internal cells from cells and cellOrder', () => {
+        const notebook = parse(NOTEBOOK_WITH_INTERNAL_CELLS);
+        assert.strictEqual(notebook.cells.size, 1);
+        assert.ok(notebook.cells.has('abcdef01-1234-5678-abcd-ef0123456789'));
+        assert.ok(!notebook.cells.has('00000000-0000-0000-0000-000000000001'));
+        assert.ok(!notebook.cells.has('00000000-0000-0000-0000-000000000002'));
+        assert.deepStrictEqual(notebook.cellOrder, ['abcdef01-1234-5678-abcd-ef0123456789']);
+    });
+
+    test('parse returns empty internalCells for notebook without them', () => {
+        const notebook = parse(NOTEBOOK_WITHOUT_INTERNAL_CELLS);
+        assert.strictEqual(notebook.internalCells.size, 0);
+        assert.strictEqual(notebook.cells.size, 1);
+    });
+
+    test('serialize writes internal cells after regular cells and before cell order', () => {
+        const notebook = parse(NOTEBOOK_WITH_INTERNAL_CELLS);
+        const output = serialize(notebook);
+        const lines = output.split('\n');
+
+        const regularCellPos = lines.findIndex((line) => line === '# ╔═╡ abcdef01-1234-5678-abcd-ef0123456789');
+        const projectCellPos = lines.findIndex((line) => line === '# ╔═╡ 00000000-0000-0000-0000-000000000001');
+        const manifestCellPos = lines.findIndex((line) => line === '# ╔═╡ 00000000-0000-0000-0000-000000000002');
+        const cellOrderPos = lines.findIndex((line) => line === '# ╔═╡ Cell order:');
+
+        assert.ok(regularCellPos > 0, 'regular cell should exist');
+        assert.ok(projectCellPos > 0, 'project toml cell should exist');
+        assert.ok(manifestCellPos > 0, 'manifest toml cell should exist');
+        assert.ok(cellOrderPos > 0, 'cell order should exist');
+
+        assert.ok(regularCellPos < projectCellPos, 'regular cell before project cell');
+        assert.ok(projectCellPos < manifestCellPos, 'project cell before manifest cell');
+        assert.ok(manifestCellPos < cellOrderPos, 'internal cells before cell order');
+    });
+
+    test('serialize writes internal cells in cell order with folded marker', () => {
+        const notebook = parse(NOTEBOOK_WITH_INTERNAL_CELLS);
+        const output = serialize(notebook);
+        const lines = output.split('\n');
+        const cellOrderStart = lines.findIndex((line) => line === '# ╔═╡ Cell order:');
+        const cellOrderLines = lines.slice(cellOrderStart + 1).filter((line) => line.startsWith('# '));
+
+        assert.ok(cellOrderLines.some((line) => line === '# ╠═abcdef01-1234-5678-abcd-ef0123456789'));
+        assert.ok(cellOrderLines.some((line) => line === '# ╟─00000000-0000-0000-0000-000000000001'));
+        assert.ok(cellOrderLines.some((line) => line === '# ╟─00000000-0000-0000-0000-000000000002'));
+
+        const regularIdx = cellOrderLines.findIndex((line) => line.includes('abcdef01'));
+        const projectIdx = cellOrderLines.findIndex((line) => line.includes('000000000001'));
+        const manifestIdx = cellOrderLines.findIndex((line) => line.includes('000000000002'));
+        assert.ok(regularIdx < projectIdx);
+        assert.ok(projectIdx < manifestIdx);
+    });
+
+    test('serialize without internal cells does not add internal markers', () => {
+        const notebook = parse(NOTEBOOK_WITHOUT_INTERNAL_CELLS);
+        const output = serialize(notebook);
+        assert.ok(!output.includes('00000000-0000-0000-0000-000000000001'));
+        assert.ok(!output.includes('00000000-0000-0000-0000-000000000002'));
+    });
+
+    test('round-trip preserves internal cells', () => {
+        const notebook1 = parse(NOTEBOOK_WITH_INTERNAL_CELLS);
+        const serialized = serialize(notebook1);
+        const notebook2 = parse(serialized);
+
+        assert.strictEqual(notebook2.internalCells.size, 2);
+        assert.strictEqual(
+            notebook2.internalCells.get('00000000-0000-0000-0000-000000000001'),
+            notebook1.internalCells.get('00000000-0000-0000-0000-000000000001')
+        );
+        assert.strictEqual(
+            notebook2.internalCells.get('00000000-0000-0000-0000-000000000002'),
+            notebook1.internalCells.get('00000000-0000-0000-0000-000000000002')
+        );
+        assert.strictEqual(notebook2.cells.size, 1);
+        assert.deepStrictEqual(notebook2.cellOrder, notebook1.cellOrder);
     });
 });


### PR DESCRIPTION
Adds test coverage for PlutoNotebookParser internal cells (TOML package metadata) handling.

**Changes**
- New suite `PlutoNotebookParser - internal cells` in `src/test/pluto-notebook-parser.test.ts`
- `isPlutoInternalCell`: recognizes known internal IDs (00000000-0000-0000-0000-000000000001/002)
- Parse: internal cells collected in `internalCells`, excluded from `cells` and `cellOrder`
- Serialize: internal cells written after regular cells and before cell order, with folded marker; round-trip preserves internal cells
- Fixtures: `NOTEBOOK_WITH_INTERNAL_CELLS` and `NOTEBOOK_WITHOUT_INTERNAL_CELLS`

README.md verified: project structure and test file references are accurate.

Made with [Cursor](https://cursor.com)