### PR TITLE
test: add unit tests for escapeHtml and renderStdoutAsHtml

### DIFF
--- a/src/PlutoNotebookController.ts
+++ b/src/PlutoNotebookController.ts
@@ -6,7 +6,7 @@ import * as vscode from 'vscode';
 import { PlutoServer, CellState, LogEntry } from './PlutoServer';
 import { getCellId, setCellId } from './PlutoNotebookSerializer';
 import { generateCellId, parse as parsePlutoNotebook } from './PlutoNotebookParser';
-import { isPlutoObjectId } from './output-utils';
+import { isPlutoObjectId, renderStdoutAsHtml, escapeHtml } from './output-utils';
 import * as fs from 'fs';
 import { log } from './extension';
 
@@ -752,9 +752,8 @@ class PlutoKernel {
 
             if (stdoutLogs) {
                 // Wrap stdout in Pluto-style terminal HTML
-                const stdoutHtml = this.renderStdoutAsHtml(stdoutLogs);
                 outputs.push(new vscode.NotebookCellOutput([
-                    vscode.NotebookCellOutputItem.text(stdoutHtml, 'application/vnd.pluto.html+html')
+                    vscode.NotebookCellOutputItem.text(renderStdoutAsHtml(stdoutLogs), 'application/vnd.pluto.html+html')
                 ]));
             }
         }
@@ -976,9 +975,8 @@ class PlutoKernel {
 
             if (stdoutLogs) {
                 // Wrap stdout in Pluto-style terminal HTML
-                const stdoutHtml = this.renderStdoutAsHtml(stdoutLogs);
                 outputs.push(new vscode.NotebookCellOutput([
-                    vscode.NotebookCellOutputItem.text(stdoutHtml, 'application/vnd.pluto.html+html')
+                    vscode.NotebookCellOutputItem.text(renderStdoutAsHtml(stdoutLogs), 'application/vnd.pluto.html+html')
                 ]));
             }
         }
@@ -1338,7 +1336,7 @@ document.addEventListener('click', function(e) {
 ${treeHtml}`;
         } catch (e) {
             log(`[BetterPlutoKernel] Tree HTML render error: ${e}`);
-            return `<pre>${this.escapeHtml(body)}</pre>`;
+            return `<pre>${escapeHtml(body)}</pre>`;
         }
     }
 
@@ -1350,14 +1348,14 @@ ${treeHtml}`;
             return '<span>nothing</span>';
         }
         if (typeof obj === 'string') {
-            return `<span>${this.escapeHtml(obj)}</span>`;
+            return `<span>${escapeHtml(obj)}</span>`;
         }
         if (typeof obj === 'number' || typeof obj === 'boolean') {
             return `<span>${obj}</span>`;
         }
 
         if (typeof obj !== 'object') {
-            return `<span>${this.escapeHtml(String(obj))}</span>`;
+            return `<span>${escapeHtml(String(obj))}</span>`;
         }
 
         // Handle arrays directly (sometimes Pluto sends just the elements array)
@@ -1375,7 +1373,7 @@ ${treeHtml}`;
                         return this.renderPlutoTree(body, false);
                     }
                     if (typeof body === 'string') {
-                        return `<span>${this.escapeHtml(body)}</span>`;
+                        return `<span>${escapeHtml(body)}</span>`;
                     }
                     return this.renderPlutoTree(body, false);
                 };
@@ -1386,7 +1384,7 @@ ${treeHtml}`;
                     if (r && typeof r === 'object' && !Array.isArray(r)) {
                         const moreObj = r as Record<string, unknown>;
                         if (moreObj.head === 'more' && moreObj.objectid) {
-                            const oid = this.escapeHtml(String(moreObj.objectid));
+                            const oid = escapeHtml(String(moreObj.objectid));
                             return `<pluto-tree-more data-objectid="${oid}">show more</pluto-tree-more>`;
                         }
                     }
@@ -1402,11 +1400,11 @@ ${treeHtml}`;
                 const isMoreMarker = (e: unknown) => e === 'more' || (e && typeof e === 'object' && !Array.isArray(e) && (e as Record<string, unknown>).head === 'more');
                 const count = obj.filter(e => !isMoreMarker(e)).length;
                 const prefix = `${count}-element Array:`;
-                const prefixHtml = `<pluto-tree-prefix><span class="long">${this.escapeHtml(prefix)}</span><span class="short">${this.escapeHtml(prefix)}</span></pluto-tree-prefix>`;
+                const prefixHtml = `<pluto-tree-prefix><span class="long">${escapeHtml(prefix)}</span><span class="short">${escapeHtml(prefix)}</span></pluto-tree-prefix>`;
                 return `<pluto-tree class="Array${collapsedClass}">${prefixHtml}<pluto-tree-items class="Array">${itemsHtml}</pluto-tree-items></pluto-tree>`;
             }
             // Otherwise, just stringify
-            return `<span>${this.escapeHtml(JSON.stringify(obj).substring(0, 100))}</span>`;
+            return `<span>${escapeHtml(JSON.stringify(obj).substring(0, 100))}</span>`;
         }
 
         const record = obj as Record<string, unknown>;
@@ -1421,7 +1419,7 @@ ${treeHtml}`;
                 return this.renderPlutoTree(body, false);
             }
             if (typeof body === 'string') {
-                return `<span>${this.escapeHtml(body)}</span>`;
+                return `<span>${escapeHtml(body)}</span>`;
             }
             return this.renderPlutoTree(body, false);
         };
@@ -1449,7 +1447,7 @@ ${treeHtml}`;
             const elements = record.elements as unknown[];
             const typeClass = plutoType || 'Array';
 
-            const prefixHtml = `<pluto-tree-prefix><span class="long">${this.escapeHtml(prefix || '')}</span><span class="short">${this.escapeHtml(prefixShort || prefix || '')}</span></pluto-tree-prefix>`;
+            const prefixHtml = `<pluto-tree-prefix><span class="long">${escapeHtml(prefix || '')}</span><span class="short">${escapeHtml(prefixShort || prefix || '')}</span></pluto-tree-prefix>`;
 
             let itemsHtml = '';
 
@@ -1461,7 +1459,7 @@ ${treeHtml}`;
                 if (r && typeof r === 'object' && !Array.isArray(r)) {
                     const obj = r as Record<string, unknown>;
                     if (obj.head === 'more' && obj.objectid) {
-                        const oid = this.escapeHtml(String(obj.objectid));
+                        const oid = escapeHtml(String(obj.objectid));
                         return `<pluto-tree-more data-objectid="${oid}">show more</pluto-tree-more>`;
                     }
                 }
@@ -1499,7 +1497,7 @@ ${treeHtml}`;
                         if (moreHtml) {return moreHtml;}
                         const el = r as unknown[];
                         if (!Array.isArray(el) || el.length !== 2) {return '';}
-                        return `<p-r><p-k>${this.escapeHtml(String(el[0]))}</p-k><p-v>${mimepairOutput(el[1] as unknown[])}</p-v></p-r>`;
+                        return `<p-r><p-k>${escapeHtml(String(el[0]))}</p-k><p-v>${mimepairOutput(el[1] as unknown[])}</p-v></p-r>`;
                     }).join('');
                     break;
 
@@ -1519,125 +1517,13 @@ ${treeHtml}`;
 
         // Fallback
         if (prefix) {
-            return `<span>${this.escapeHtml(prefix)}</span>`;
+            return `<span>${escapeHtml(prefix)}</span>`;
         }
         if (plutoType) {
-            return `<span>&lt;${this.escapeHtml(plutoType)}&gt;</span>`;
+            return `<span>&lt;${escapeHtml(plutoType)}&gt;</span>`;
         }
 
-        return `<span>${this.escapeHtml(JSON.stringify(obj).substring(0, 100))}</span>`;
-    }
-
-    /**
-     * Escape HTML special characters
-     */
-    private escapeHtml(str: string): string {
-        return str
-            .replace(/&/g, '&amp;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;')
-            .replace(/"/g, '&quot;')
-            .replace(/'/g, '&#039;');
-    }
-
-    /**
-     * Render stdout as Pluto-style terminal HTML
-     * Based on Pluto.jl's Logs.js and editor.css styling
-     */
-    private renderStdoutAsHtml(stdout: string): string {
-        const escapedStdout = this.escapeHtml(stdout);
-
-        return `
-<style>
-/* Pluto.jl Stdout Terminal Styling */
-.pluto-stdout-container {
-    display: block;
-    margin: 4px 0;
-}
-
-.pluto-stdout {
-    /* CRT terminal style - based on Pluto.jl editor.css */
-    --inner: hsl(36deg 20% 37%);
-    --outer: hsl(31deg 12% 28%);
-    background: radial-gradient(var(--inner), var(--inner) 20%, var(--outer));
-    color: #c0ffab;
-    border: 4px solid #b7b7b7;
-    text-shadow: 1px 1px 2px #0000005e;
-    border-radius: 6px;
-    padding: 8px 12px;
-    font-family: "JuliaMono", "Fira Code", "Roboto Mono", monospace;
-    font-size: 0.85em;
-    position: relative;
-    overflow: hidden;
-    min-width: 12em;
-    max-width: 100%;
-    white-space: pre-wrap;
-    word-break: break-word;
-}
-
-/* CRT scanline effect overlay */
-.pluto-stdout::before {
-    content: "";
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    opacity: 0.15;
-    background: linear-gradient(349deg, #000000, transparent);
-    pointer-events: none;
-}
-
-.pluto-stdout::after {
-    content: "";
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    --crt-spacing: 5px;
-    background: linear-gradient(180deg, hsl(37deg 20% 27%), transparent, #1a1a1a);
-    background-size: 100% var(--crt-spacing);
-    opacity: 0.08;
-    pointer-events: none;
-}
-
-/* Terminal icon label */
-.pluto-stdout-label {
-    display: flex;
-    align-items: center;
-    gap: 4px;
-    font-size: 0.75em;
-    color: #888;
-    margin-bottom: 4px;
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-}
-
-.pluto-stdout-label svg {
-    width: 14px;
-    height: 14px;
-    opacity: 0.7;
-}
-
-/* Light theme adjustments */
-@media (prefers-color-scheme: light) {
-    .pluto-stdout {
-        --inner: hsl(36deg 15% 45%);
-        --outer: hsl(31deg 10% 38%);
-        border-color: #999;
-    }
-}
-</style>
-<div class="pluto-stdout-container">
-    <div class="pluto-stdout-label">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="currentColor">
-            <path d="M448 96H64c-17.67 0-32 14.33-32 32v256c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32V128c0-17.67-14.33-32-32-32zm8 288c0 4.41-3.59 8-8 8H64c-4.41 0-8-3.59-8-8V128c0-4.41 3.59-8 8-8h384c4.41 0 8 3.59 8 8v256z"/>
-            <path d="M168 168l-88 88 88 88 22.63-22.63L125.25 256l65.38-65.37L168 168zM344 168l-22.63 22.63L386.75 256l-65.38 65.37L344 344l88-88-88-88z"/>
-        </svg>
-        stdout
-    </div>
-    <pre class="pluto-stdout">${escapedStdout}</pre>
-</div>`;
+        return `<span>${escapeHtml(JSON.stringify(obj).substring(0, 100))}</span>`;
     }
 
     /**

--- a/src/output-utils.ts
+++ b/src/output-utils.ts
@@ -171,3 +171,115 @@ export function buildOutputItems(
 
     return items;
 }
+
+/**
+ * Escape HTML special characters
+ */
+export function escapeHtml(str: string): string {
+    return str
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
+}
+
+/**
+ * Render stdout as Pluto-style terminal HTML
+ * Based on Pluto.jl's Logs.js and editor.css styling
+ */
+export function renderStdoutAsHtml(stdout: string): string {
+    const escapedStdout = escapeHtml(stdout);
+
+    return `
+<style>
+/* Pluto.jl Stdout Terminal Styling */
+.pluto-stdout-container {
+    display: block;
+    margin: 4px 0;
+}
+
+.pluto-stdout {
+    /* CRT terminal style - based on Pluto.jl editor.css */
+    --inner: hsl(36deg 20% 37%);
+    --outer: hsl(31deg 12% 28%);
+    background: radial-gradient(var(--inner), var(--inner) 20%, var(--outer));
+    color: #c0ffab;
+    border: 4px solid #b7b7b7;
+    text-shadow: 1px 1px 2px #0000005e;
+    border-radius: 6px;
+    padding: 8px 12px;
+    font-family: "JuliaMono", "Fira Code", "Roboto Mono", monospace;
+    font-size: 0.85em;
+    position: relative;
+    overflow: hidden;
+    min-width: 12em;
+    max-width: 100%;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+/* CRT scanline effect overlay */
+.pluto-stdout::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    opacity: 0.15;
+    background: linear-gradient(349deg, #000000, transparent);
+    pointer-events: none;
+}
+
+.pluto-stdout::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    --crt-spacing: 5px;
+    background: linear-gradient(180deg, hsl(37deg 20% 27%), transparent, #1a1a1a);
+    background-size: 100% var(--crt-spacing);
+    opacity: 0.08;
+    pointer-events: none;
+}
+
+/* Terminal icon label */
+.pluto-stdout-label {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 0.75em;
+    color: #888;
+    margin-bottom: 4px;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.pluto-stdout-label svg {
+    width: 14px;
+    height: 14px;
+    opacity: 0.7;
+}
+
+/* Light theme adjustments */
+@media (prefers-color-scheme: light) {
+    .pluto-stdout {
+        --inner: hsl(36deg 15% 45%);
+        --outer: hsl(31deg 10% 38%);
+        border-color: #999;
+    }
+}
+</style>
+<div class="pluto-stdout-container">
+    <div class="pluto-stdout-label">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="currentColor">
+            <path d="M448 96H64c-17.67 0-32 14.33-32 32v256c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32V128c0-17.67-14.33-32-32-32zm8 288c0 4.41-3.59 8-8 8H64c-4.41 0-8-3.59-8-8V128c0-4.41 3.59-8 8-8h384c4.41 0 8 3.59 8 8v256z"/>
+            <path d="M168 168l-88 88 88 88 22.63-22.63L125.25 256l65.38-65.37L168 168zM344 168l-22.63 22.63L386.75 256l-65.38 65.37L344 344l88-88-88-88z"/>
+        </svg>
+        stdout
+    </div>
+    <pre class="pluto-stdout">${escapedStdout}</pre>
+</div>`;
+}

--- a/src/test/output-utils.test.ts
+++ b/src/test/output-utils.test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import { isPlutoObjectId, buildOutputItems, CachedOutput } from '../output-utils';
+import { isPlutoObjectId, buildOutputItems, CachedOutput, escapeHtml, renderStdoutAsHtml } from '../output-utils';
 
 suite('Output Utils - isPlutoObjectId', () => {
     test('returns true for valid 14-char hex objectid', () => {
@@ -277,5 +277,102 @@ suite('Output Utils - Race Condition Scenario', () => {
         assert.strictEqual(items.length, 1);
         assert.strictEqual(items[0].type, 'stdout');
         assert.strictEqual(items[0].content, 'Compiling packages...\n');
+    });
+});
+
+suite('Output Utils - escapeHtml', () => {
+    test('escapes ampersand', () => {
+        assert.strictEqual(escapeHtml('a & b'), 'a &amp; b');
+    });
+
+    test('escapes less than', () => {
+        assert.strictEqual(escapeHtml('a < b'), 'a &lt; b');
+    });
+
+    test('escapes greater than', () => {
+        assert.strictEqual(escapeHtml('a > b'), 'a &gt; b');
+    });
+
+    test('escapes double quotes', () => {
+        assert.strictEqual(escapeHtml('a "b" c'), 'a &quot;b&quot; c');
+    });
+
+    test('escapes single quotes', () => {
+        assert.strictEqual(escapeHtml("a 'b' c"), 'a &#039;b&#039; c');
+    });
+
+    test('escapes all special characters in one string', () => {
+        assert.strictEqual(
+            escapeHtml('<div class="test">a & b\'s</div>'),
+            '&lt;div class=&quot;test&quot;&gt;a &amp; b&#039;s&lt;/div&gt;'
+        );
+    });
+
+    test('returns empty string for empty input', () => {
+        assert.strictEqual(escapeHtml(''), '');
+    });
+
+    test('returns unchanged string with no special characters', () => {
+        assert.strictEqual(escapeHtml('Hello World'), 'Hello World');
+    });
+});
+
+suite('Output Utils - renderStdoutAsHtml', () => {
+    test('returns HTML with pluto-stdout-container class', () => {
+        const html = renderStdoutAsHtml('Hello');
+        assert.ok(html.includes('class="pluto-stdout-container"'));
+    });
+
+    test('returns HTML with pluto-stdout class', () => {
+        const html = renderStdoutAsHtml('Hello');
+        assert.ok(html.includes('class="pluto-stdout"'));
+    });
+
+    test('returns HTML with stdout label', () => {
+        const html = renderStdoutAsHtml('Hello');
+        assert.ok(html.includes('class="pluto-stdout-label"'));
+        assert.ok(html.includes('stdout'));
+    });
+
+    test('escapes HTML characters in stdout content', () => {
+        const html = renderStdoutAsHtml('<script>alert("xss")</script>');
+        assert.ok(html.includes('&lt;script&gt;'));
+        assert.ok(!html.includes('<script>alert'));
+    });
+
+    test('preserves newlines in pre tag', () => {
+        const html = renderStdoutAsHtml('line1\nline2\nline3');
+        assert.ok(html.includes('line1\nline2\nline3'));
+    });
+
+    test('includes CRT terminal styling CSS', () => {
+        const html = renderStdoutAsHtml('test');
+        assert.ok(html.includes('--inner: hsl(36deg 20% 37%)'));
+        assert.ok(html.includes('color: #c0ffab'));
+        assert.ok(html.includes('radial-gradient'));
+    });
+
+    test('includes terminal icon SVG', () => {
+        const html = renderStdoutAsHtml('test');
+        assert.ok(html.includes('<svg'));
+        assert.ok(html.includes('viewBox="0 0 512 512"'));
+    });
+
+    test('wraps content in pre tag', () => {
+        const html = renderStdoutAsHtml('test output');
+        assert.ok(html.includes('<pre class="pluto-stdout">test output</pre>'));
+    });
+
+    test('handles empty string', () => {
+        const html = renderStdoutAsHtml('');
+        assert.ok(html.includes('<pre class="pluto-stdout"></pre>'));
+    });
+
+    test('handles multiline output with special characters', () => {
+        const input = 'Line 1: x > 0\nLine 2: y < 10\nLine 3: "test"';
+        const html = renderStdoutAsHtml(input);
+        assert.ok(html.includes('x &gt; 0'));
+        assert.ok(html.includes('y &lt; 10'));
+        assert.ok(html.includes('&quot;test&quot;'));
     });
 });


### PR DESCRIPTION
## Summary

- Extract `escapeHtml` and `renderStdoutAsHtml` functions to `output-utils.ts` for testability
- Add unit tests for the stdout HTML rendering feature from PR #40
- Update `PlutoNotebookController` to use imported functions

## Tests Added

### escapeHtml (8 tests)
- Escapes ampersand, less than, greater than
- Escapes single and double quotes
- Handles combined special characters
- Edge cases: empty string, no special characters

### renderStdoutAsHtml (10 tests)
- HTML structure: container class, stdout class, label
- XSS prevention: escapes script tags and HTML characters
- Preserves newlines in pre tag
- Includes CRT terminal styling CSS
- Includes terminal icon SVG
- Edge cases: empty string, multiline with special chars

## Test Results
```
93 passing (33ms)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)