### PR TITLE
test(e2e): add PlutoTeachingTools.jl to E2E suite

### DIFF
--- a/src/test/pluto-basic-e2e.test.ts
+++ b/src/test/pluto-basic-e2e.test.ts
@@ -29,7 +29,7 @@ function hasJuliaInPath(): boolean {
     return result.status === 0;
 }
 
-suite('Pluto Basic E2E', () => {
+suite('Pluto E2E', () => {
     test('open Basic.jl as Pluto notebook and execute a cell', async function () {
         this.timeout(240_000);
 
@@ -71,6 +71,64 @@ suite('Pluto Basic E2E', () => {
         );
 
         assert.ok(notebook.cellAt(1).outputs.length > 0, 'Expected executed cell to have outputs');
+
+        await vscode.commands.executeCommand('pluto-notebook.stopKernel');
+    });
+
+    test('open PlutoTeachingTools.jl as Pluto notebook and execute a cell', async function () {
+        this.timeout(240_000);
+
+        if (process.env.RUN_PLUTO_E2E !== '1') {
+            this.skip();
+            return;
+        }
+
+        if (!hasJuliaInPath()) {
+            this.skip();
+            return;
+        }
+
+        const samplePath = path.resolve(__dirname, '..', '..', 'samples', 'PlutoTeachingTools.jl');
+        assert.ok(fs.existsSync(samplePath), `Sample notebook not found: ${samplePath}`);
+
+        const uri = vscode.Uri.file(samplePath);
+        await vscode.commands.executeCommand('vscode.openWith', uri, NOTEBOOK_TYPE);
+
+        const notebookEditor = await waitFor(
+            () => vscode.window.activeNotebookEditor,
+            (editor) => editor.notebook.notebookType === NOTEBOOK_TYPE,
+            30_000
+        );
+
+        const notebook = notebookEditor.notebook;
+        assert.ok(notebook.cellCount > 1, 'Expected PlutoTeachingTools.jl to have at least two cells');
+
+        await vscode.commands.executeCommand('pluto-notebook.startKernel');
+
+        // Find a code cell that contains println and execute it (e.g. println("Hello, World!"))
+        let targetIndex = -1;
+        for (let i = 0; i < notebook.cellCount; i++) {
+            const cell = notebook.cellAt(i);
+            if (cell.kind === vscode.NotebookCellKind.Code) {
+                const text = cell.document.getText();
+                if (text.includes('println')) {
+                    targetIndex = i;
+                    break;
+                }
+            }
+        }
+        assert.ok(targetIndex >= 0, 'Expected to find a code cell containing println in PlutoTeachingTools.jl');
+
+        notebookEditor.selection = new vscode.NotebookRange(targetIndex, targetIndex + 1);
+        await vscode.commands.executeCommand('notebook.cell.execute');
+
+        await waitFor(
+            () => notebook.cellAt(targetIndex).outputs,
+            (outputs) => outputs.length > 0,
+            120_000
+        );
+
+        assert.ok(notebook.cellAt(targetIndex).outputs.length > 0, 'Expected executed cell to have outputs');
 
         await vscode.commands.executeCommand('pluto-notebook.stopKernel');
     });


### PR DESCRIPTION
## Summary
Adds `samples/PlutoTeachingTools.jl` as an E2E test target alongside Basic.jl.

## Changes
- **Suite rename**: `Pluto Basic E2E` → `Pluto E2E`
- **New test**: `open PlutoTeachingTools.jl as Pluto notebook and execute a cell`
  - Opens `samples/PlutoTeachingTools.jl`, starts kernel, finds the first code cell containing `println`, executes it, and asserts output (runs when `RUN_PLUTO_E2E=1` and Julia is in PATH).

## Verification
`RUN_PLUTO_E2E=1 yarn test` — 109 passing (both Basic.jl and PlutoTeachingTools.jl E2E pass).

Made with [Cursor](https://cursor.com)