### PR TITLE
Fix 6 bugs: server state, dead code, regex, and dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "test": "vscode-test"
   },
   "dependencies": {
-    "@msgpack/msgpack": "^3.0.0-beta2",
+    "@msgpack/msgpack": "^3.1.0",
     "ws": "^8.18.0"
   },
   "devDependencies": {
@@ -174,8 +174,5 @@
     "typescript-eslint": "^8.52.0",
     "webpack": "^5.104.1",
     "webpack-cli": "^6.0.1"
-  },
-  "resolutions": {
-    "diff": "^8.0.3"
   }
 }

--- a/src/PlutoNotebookParser.ts
+++ b/src/PlutoNotebookParser.ts
@@ -19,10 +19,11 @@ export interface PlutoNotebook {
     internalCells: Map<string, string>;  // cellId -> code content
 }
 
-const CELL_MARKER = /^# ╔═╡ ([0-9a-f-]+)$/;
+const UUID_PATTERN = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}';
+const CELL_MARKER = new RegExp(`^# ╔═╡ (${UUID_PATTERN})$`);
 const CELL_ORDER_START = /^# ╔═╡ Cell order:$/;
 // Cell order uses ╠═ for visible cells or ╟─ for hidden (folded) cells
-const CELL_ORDER_ITEM = /^# ([╠╟])[═─]([0-9a-f-]+)$/;
+const CELL_ORDER_ITEM = new RegExp(`^# ([╠╟])[═─](${UUID_PATTERN})$`);
 const VERSION_PATTERN = /^# v(\d+\.\d+\.\d+)$/;
 
 // Pluto.jl internal cell IDs for package management (should be filtered out)

--- a/src/PlutoServer.ts
+++ b/src/PlutoServer.ts
@@ -132,8 +132,6 @@ export class PlutoServer extends EventEmitter {
     private connectDelayTimeout: NodeJS.Timeout | null = null;
     private resetSharedStateTimeout: NodeJS.Timeout | null = null;
 
-    private vscodeToPlutoId = new Map<string, string>();
-    private plutoToVscodeId = new Map<string, string>();
     private waitTimers = new Set<NodeJS.Timeout>();
 
     private readonly scheduler: Scheduler;
@@ -408,6 +406,7 @@ export class PlutoServer extends EventEmitter {
                 }
             }
         } catch (err) {
+            this.logger(`[BetterPlutoServer] Failed to process message: ${err}`);
             this.emit('error', err as Error);
         }
     }
@@ -520,11 +519,11 @@ export class PlutoServer extends EventEmitter {
     }
 
     getPlutoCellId(vscodeCellId: string): string {
-        return this.vscodeToPlutoId.get(vscodeCellId) || vscodeCellId;
+        return vscodeCellId;
     }
 
     getVscodeCellId(plutoId: string): string {
-        return this.plutoToVscodeId.get(plutoId) || plutoId;
+        return plutoId;
     }
 
     async waitForCellToAppear(cellId: string, code: string = ''): Promise<string> {
@@ -582,17 +581,21 @@ export class PlutoServer extends EventEmitter {
     }
 
     async updateCellOrder(newOrder: string[]): Promise<void> {
-        this.cellOrder = [...newOrder];
+        const orderCopy = [...newOrder];
 
-        this.sendMessage('update_notebook', {
+        const sent = this.sendMessage('update_notebook', {
             updates: [
                 {
                     path: ['cell_order'],
                     op: 'replace',
-                    value: this.cellOrder,
+                    value: orderCopy,
                 },
             ],
         });
+
+        if (sent) {
+            this.cellOrder = orderCopy;
+        }
     }
 
     async updateCell(cellId: string, code: string): Promise<void> {
@@ -644,8 +647,6 @@ export class PlutoServer extends EventEmitter {
         this.knownCellIds.clear();
         this.cellOrder = [];
         this.pendingCellIds.clear();
-        this.vscodeToPlutoId.clear();
-        this.plutoToVscodeId.clear();
         this.notebookId = '';
 
         if (this.transport) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -154,7 +154,7 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@msgpack/msgpack@^3.0.0-beta2":
+"@msgpack/msgpack@^3.1.0":
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/@msgpack/msgpack/-/msgpack-3.1.3.tgz#c4bff2b9539faf0882f3ee03537a7e9a4b3a7864"
   integrity sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA==
@@ -816,10 +816,10 @@ deep-is@^0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
-diff@^7.0.0, diff@^8.0.3:
-  version "8.0.3"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-8.0.3.tgz#c7da3d9e0e8c283bb548681f8d7174653720c2d5"
-  integrity sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==
+diff@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-7.0.0.tgz#3fb34d387cd76d803f6eebea67b921dab0182a9a"
+  integrity sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==
 
 eastasianwidth@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
## Summary

- **Fix #75**: `updateCellOrder` now updates local state only after successful message send, preventing client-server desynchronization
- **Fix #84**: Add error logging for message processing failures in `handleMessage`
- **Fix #85**: Remove unused `vscodeToPlutoId`/`plutoToVscodeId` maps and simplify ID getters
- **Fix #86**: Tighten cell ID regex from permissive `[0-9a-f-]+` to strict UUID pattern
- **Fix #87**: Remove `resolutions` override for `diff@^8.0.3` conflicting with mocha's `diff@^7`
- **Fix #88**: Update `@msgpack/msgpack` from `^3.0.0-beta2` to `^3.1.0` (stable)

Additionally confirmed that issues #76, #77, #78, #79, #80, #81, #83 were already fixed in prior commits (#89, #91).

## Test plan

- [x] `yarn compile` builds successfully
- [ ] Verify Pluto notebook cell operations work correctly (add, delete, reorder)
- [ ] Verify `.jl` file parsing with strict UUID validation
- [ ] Verify `yarn install` resolves dependencies without conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)